### PR TITLE
virtual_ptr/wfunc_ptr: Add include for bitutils

### DIFF
--- a/src/utils/virtual_ptr.h
+++ b/src/utils/virtual_ptr.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "types.h"
+#include "bitutils.h"
 #include "memory_translate.h"
 
 template<typename Type, bool IsBigEndian = false>

--- a/src/utils/wfunc_ptr.h
+++ b/src/utils/wfunc_ptr.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ostream>
+#include "bitutils.h"
 #include "ppctypes.h"
 #include "utils/virtual_ptr.h"
 


### PR DESCRIPTION
Since it uses byte_swap, this will ensure it doesn't fail to compile due to an external missing include.