### PR TITLE
Fix initializer list order

### DIFF
--- a/src/mem/mem.cpp
+++ b/src/mem/mem.cpp
@@ -31,12 +31,12 @@ enum class MemoryType
 struct MemoryView
 {
    MemoryView() :
-      address(0)
+      address(nullptr)
    {
    }
 
    MemoryView(MemoryType type, uint32_t start, uint32_t end, uint32_t pageSize) :
-      type(type), start(start), end(end), address(0), pageSize(pageSize)
+      type(type), start(start), end(end), address(nullptr), pageSize(pageSize)
    {
    }
 

--- a/src/mem/mem.cpp
+++ b/src/mem/mem.cpp
@@ -36,7 +36,7 @@ struct MemoryView
    }
 
    MemoryView(MemoryType type, uint32_t start, uint32_t end, uint32_t pageSize) :
-      type(type), start(start), end(end), pageSize(pageSize), address(0)
+      type(type), start(start), end(end), address(0), pageSize(pageSize)
    {
    }
 

--- a/src/modules/nn_result.h
+++ b/src/modules/nn_result.h
@@ -67,9 +67,9 @@ union Result
    }
 
    Result(int32_t module, int32_t level, int32_t description) :
+      description(description),
       module(module),
-      level(level),
-      description(description)
+      level(level)
    {
    }
 


### PR DESCRIPTION
Will stifle eventual warnings on compilers other than MSVC.