### PR TITLE
Explicitly include various header files

### DIFF
--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <functional>
 #include <utility>
+#include "ppcinvoke.h"
 #include "state.h"
 
 struct ThreadState;

--- a/src/cpu/disassembler.cpp
+++ b/src/cpu/disassembler.cpp
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <iomanip>
+#include <list>
 #include "disassembler.h"
 #include "instructiondata.h"
 #include "system.h"

--- a/src/cpu/instructiondata.h
+++ b/src/cpu/instructiondata.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <string>
 #include <vector>
 #include "instruction.h"
 #include "instructionid.h"

--- a/src/cpu/interpreter/interpreter_condition.cpp
+++ b/src/cpu/interpreter/interpreter_condition.cpp
@@ -1,3 +1,4 @@
+#include <utility>
 #include "interpreter_insreg.h"
 #include "utils/bitutils.h"
 #include "utils/floatutils.h"

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -1,8 +1,9 @@
 #pragma once
+#include <atomic>
 #include <cstdint>
 #include <map>
 #include <mutex>
-#include <atomic>
+#include <thread>
 #include <queue>
 #include "debugmsg.h"
 #include "modules/coreinit/coreinit_core.h"

--- a/src/platform/platform_posix_thread.cpp
+++ b/src/platform/platform_posix_thread.cpp
@@ -3,6 +3,7 @@
 
 #include <ctime>
 #include <thread>
+#include <string>
 
 namespace platform
 {

--- a/src/utils/crc32.cpp
+++ b/src/utils/crc32.cpp
@@ -1,5 +1,3 @@
-#include <stdint.h>
-
 /*-
 *  COPYRIGHT (C) 1986 Gary S. Brown.  You may use this program, or
 *  code or tables extracted from it, as desired without restriction.
@@ -41,6 +39,9 @@
 *
 * CRC32 code derived from work by Gary S. Brown.
 */
+
+#include <stddef.h>
+#include <stdint.h>
 
 static uint32_t crc32_tab[] = {
    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,


### PR DESCRIPTION
These header files were implicitly included, to the point where their contents were not able to be found on non-MSVC build systems.