### PR TITLE
Wrap or change bound functions with `long` return values

### DIFF
--- a/src/modules/coreinit/coreinit_thread.cpp
+++ b/src/modules/coreinit/coreinit_thread.cpp
@@ -67,7 +67,7 @@ OSCancelThread(OSThread *thread)
    }
 }
 
-long
+int32_t
 OSCheckActiveThreads()
 {
    // TODO: Count threads in active thread queue

--- a/src/modules/coreinit/coreinit_thread.h
+++ b/src/modules/coreinit/coreinit_thread.h
@@ -199,7 +199,7 @@ using ThreadEntryPoint = wfunc_ptr<uint32_t, uint32_t, void*>;
 void
 OSCancelThread(OSThread *thread);
 
-long
+int32_t
 OSCheckActiveThreads();
 
 int32_t

--- a/src/modules/zlib125/zlib125_core.cpp
+++ b/src/modules/zlib125/zlib125_core.cpp
@@ -156,18 +156,40 @@ zlib125_inflateEnd(WZStream *wstrm)
    return result;
 }
 
+static uint32_t
+zlib125_adler32(uint32_t adler, const Bytef * buf, unsigned len)
+{
+   return (uint32_t)adler32(adler, buf, len);
+}
+
+static uint32_t
+zlib125_crc32(uint32_t crc, const Bytef * buf, unsigned len)
+{
+   return (uint32_t)crc32(crc, buf, len);
+}
+
+static uint32_t
+zlib125_compressBound(uint32_t sourceLen)
+{
+   return (uint32_t)compressBound(sourceLen);
+}
+
+static uint32_t
+zlib125_zlibCompileFlags()
+{
+   return (uint32_t)zlibCompileFlags();
+}
+
 void
 Zlib125::registerCoreFunctions()
 {
-   // Functions we can do directly!
-   RegisterKernelFunction(adler32);
-   RegisterKernelFunction(crc32);
-   RegisterKernelFunction(compressBound);
-   RegisterKernelFunction(zlibCompileFlags);
-
    // Need wrap
+   RegisterKernelFunctionName("adler32", zlib125_adler32);
+   RegisterKernelFunctionName("crc32", zlib125_crc32);
    RegisterKernelFunctionName("inflate", zlib125_inflate);
    RegisterKernelFunctionName("inflateInit_", zlib125_inflateInit_);
    RegisterKernelFunctionName("inflateInit2_", zlib125_inflateInit2_);
    RegisterKernelFunctionName("inflateEnd", zlib125_inflateEnd);
+   RegisterKernelFunctionName("compressBound", zlib125_compressBound);
+   RegisterKernelFunctionName("zlibCompileFlags", zlib125_zlibCompileFlags);
 }


### PR DESCRIPTION
`long`'s size can change depending on the platform. On Windows it is always 32-bit, while on other platforms it can be 32-bit or 64-bit depending on the bitness of the OS. To mitigate this problem, use `int32_t` or `uint32_t` instead where appropriate.