### PR TITLE
system: Get rid of a _strdup usage

### DIFF
--- a/src/cpu/disassembler.cpp
+++ b/src/cpu/disassembler.cpp
@@ -325,7 +325,7 @@ Disassembler::disassemble(Instruction instr, Disassembly &dis, uint32_t address)
    if (data->id == InstructionID::kc) {
       auto sc = gSystem.getSyscallData(dis.args[0].constantUnsigned);
       if (sc) {
-         dis.text += " ; " + std::string(sc->name);
+         dis.text += " ; " + sc->name;
       } else {
          dis.text += " ; ?";
       }

--- a/src/kernelexport.h
+++ b/src/kernelexport.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 struct KernelExport
 {
    enum Type
@@ -24,6 +26,6 @@ struct KernelExport
    }
 
    Type type;
-   const char *name;
+   std::string name;
    void *ppcPtr;
 };

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -252,7 +252,7 @@ Loader::loadRPL(std::string name)
 
    // Try to find module in system kernel library list
    if (!module) {
-      auto kernelModule = gSystem.findModule(name.c_str());
+      auto kernelModule = gSystem.findModule(name);
 
       if (kernelModule) {
          module = loadKernelModule(name, kernelModule);
@@ -431,7 +431,7 @@ Loader::registerUnimplementedFunction(const std::string& name)
       return itr->second;
    }
 
-   auto id = gSystem.registerUnimplementedFunction(name.c_str());
+   auto id = gSystem.registerUnimplementedFunction(name);
    auto thunk = static_cast<uint32_t*>(OSAllocFromSystem(8, 4));
    auto addr = mem::untranslate(thunk);
 

--- a/src/ppcinvoke.h
+++ b/src/ppcinvoke.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 #include "config.h"
 #include "ppcinvokeargs.h"
 #include "ppcinvokeresult.h"
@@ -121,7 +122,7 @@ invoke2(_argumentsState& state, void func(FnArgs...), type_list<>, Args... args)
 
 template<typename ReturnType, typename... Args>
 inline void
-invoke(ThreadState *state, ReturnType func(Args...), const char *name = nullptr)
+invoke(ThreadState *state, ReturnType func(Args...), const std::string &name = "")
 {
    _argumentsState argstate;
    argstate.thread = state;

--- a/src/ppcinvokelog.h
+++ b/src/ppcinvokelog.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdio>
+#include <string>
 #include "config.h"
 #include "utils/virtual_ptr.h"
 
@@ -15,10 +16,10 @@ struct LogState
 };
 
 static inline void
-logCall(LogState &state, uint32_t lr, const char *name)
+logCall(LogState &state, uint32_t lr, const std::string &name)
 {
    if (config::log::kernel_trace) {
-      auto len = sprintf_s(state.buffer + state.pos, state.length, "0x%08X %s(", lr, name);
+      auto len = sprintf_s(state.buffer + state.pos, state.length, "0x%08X %s(", lr, name.c_str());
       state.length -= len;
       state.pos += len;
    }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -35,20 +35,20 @@ System::registerSysCall(KernelFunction *func)
 }
 
 uint32_t
-System::registerUnimplementedFunction(const char* name)
+System::registerUnimplementedFunction(const std::string &name)
 {
    auto ppcFn = new kernel::functions::KernelFunctionImpl<void>();
    ppcFn->valid = false;
-   ppcFn->name = _strdup(name);
+   ppcFn->name = name;
    ppcFn->wrapped_function = nullptr;
    registerSysCall(ppcFn);
    return ppcFn->syscallID;
 }
 
 void
-System::registerModule(const char *name, KernelModule *module)
+System::registerModule(const std::string &name, KernelModule *module)
 {
-   mSystemModules.insert(std::make_pair(std::move(name), module));
+   mSystemModules.emplace(name, module);
 
    // Map syscall IDs
    auto exports = module->getExportMap();
@@ -82,7 +82,7 @@ System::initialise()
 }
 
 KernelModule *
-System::findModule(const char *name) const
+System::findModule(const std::string &name) const
 {
    auto itr = mSystemModules.find(name);
 

--- a/src/system.h
+++ b/src/system.h
@@ -38,9 +38,9 @@ public:
 
    void initialise();
 
-   uint32_t registerUnimplementedFunction(const char* name);
-   void registerModule(const char *name, KernelModule *module);
-   KernelModule *findModule(const char *name) const;
+   uint32_t registerUnimplementedFunction(const std::string &name);
+   void registerModule(const std::string &name, KernelModule *module);
+   KernelModule *findModule(const std::string &name) const;
 
    void setUserModule(LoadedModule *module);
    LoadedModule *getUserModule() const;


### PR DESCRIPTION
Also adjusts the API of the system class to use std::string