### PR TITLE
coreinit_alarm: apply not to entire if statement, not left side

### DIFF
--- a/src/modules/coreinit/coreinit_alarm.cpp
+++ b/src/modules/coreinit/coreinit_alarm.cpp
@@ -22,7 +22,7 @@ OSAlarm::Tag;
 static BOOL
 OSCancelAlarmNoLock(OSAlarm *alarm)
 {
-   if (!alarm->state == OSAlarmState::Set) {
+   if (alarm->state != OSAlarmState::Set) {
       return FALSE;
    }
 


### PR DESCRIPTION
The previous functionality would be analogous to:
```
if ((!alarm->state) == OSAlarmState::Set) {
	...
}
```