### PR TITLE
Add .travis.yml for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+os:
+    - linux
+
+language: cpp
+
+sudo: required
+dist: trusty
+
+install:
+  - cd ~
+  - sudo apt-add-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install gcc-5 g++-5 xorg-dev libglu1-mesa-dev libxcursor-dev
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
+  - git clone https://github.com/glfw/glfw --branch 3.1.2 --depth 1
+  - mkdir -p glfw/build && cd glfw/build
+  - cmake -DBUILD_SHARED_LIBS=ON -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF ..
+  - make -j4 && sudo make install
+
+script:
+  - cd "$TRAVIS_BUILD_DIR"
+  - mkdir cbuild && cd cbuild
+  - cmake ..
+  - make -j4


### PR DESCRIPTION
Before merging, make sure to enable the repository on https://travis-ci.org.