### PR TITLE
Warning fixes

### DIFF
--- a/src/cpu/disassembler.cpp
+++ b/src/cpu/disassembler.cpp
@@ -217,6 +217,8 @@ argumentToText(Disassembly::Argument &arg)
       return std::to_string(arg.constantUnsigned);
    case Disassembly::Argument::ConstantSigned:
       return std::to_string(arg.constantSigned);
+   case Disassembly::Argument::Invalid:
+      return std::string("???");
    }
 
    return std::string();

--- a/src/cpu/trace.cpp
+++ b/src/cpu/trace.cpp
@@ -185,6 +185,8 @@ getFieldStateField(Instruction instr, Field field)
          return StateField::GQR + 6;
       case SprEncoding::GQR7:
          return StateField::GQR + 7;
+      default:
+         break;
       }
       break;
    case Field::bo:
@@ -223,6 +225,8 @@ getFieldStateField(Instruction instr, Field field)
       return StateField::FPSCR;
    case Field::RSRV:
       return StateField::ReserveAddress;
+   default:
+      break;
    }
    return StateField::Invalid;
 }

--- a/src/debugger.cpp
+++ b/src/debugger.cpp
@@ -99,6 +99,9 @@ Debugger::handleMessage(DebugMessage *msg)
 
       break;
    }
+   case DebugMessageType::Invalid:
+      gLog->debug("Invalid message");
+      break;
    }
 }
 

--- a/src/debugmsg.h
+++ b/src/debugmsg.h
@@ -5,6 +5,8 @@ class MessageClass {
 public:
    typedef Type IdType;
 
+   virtual ~MessageClass() = default;
+
    virtual Type type() const = 0;
 
    bool isA(Type typeId) const {

--- a/src/debugnet.cpp
+++ b/src/debugnet.cpp
@@ -761,6 +761,8 @@ DebugNet::handlePacket(DebugPacket *pak)
 
       break;
    }
+   default:
+      break;
    }
 }
 

--- a/src/debugnet.cpp
+++ b/src/debugnet.cpp
@@ -667,7 +667,7 @@ DebugNet::handlePacket(DebugPacket *pak)
    case DebugPacketType::StepCoreOver: {
       auto *scPak = static_cast<DebugPacketStepCoreOver*>(pak);
 
-      if (scPak->coreId < 0 || scPak->coreId >= 3) {
+      if (scPak->coreId >= 3) {
          break;
       }
 

--- a/src/fuzztests.cpp
+++ b/src/fuzztests.cpp
@@ -132,7 +132,7 @@ bool
 compareStateField(int field, const TraceFieldValue &x, const TraceFieldValue &y)
 {
    if (field >= StateField::FPR0 && field <= StateField::FPR31) {
-      return abs(x.f64v0 - y.f64v0) < 0.0001 && abs(x.f64v1 - y.f64v1) < 0.0001;
+      return fabs(x.f64v0 - y.f64v0) < 0.0001 && fabs(x.f64v1 - y.f64v1) < 0.0001;
    }
    return x.u64v0 == y.u64v0 && x.u64v1 == y.u64v1;
 }

--- a/src/fuzztests.cpp
+++ b/src/fuzztests.cpp
@@ -200,6 +200,8 @@ executeInstrTest(uint32_t test_seed)
    case InstructionID::mtsrin:
       // Supervisory Instructions
       return true;
+   default:
+      break;
    }
 
    const InstructionData *data = gInstructionTable.find(instrId);

--- a/src/gpu/latte_decoder.cpp
+++ b/src/gpu/latte_decoder.cpp
@@ -154,7 +154,7 @@ decodeExport(DecodeState &state, cf::inst id, cf::Instruction &cf)
    exp->src.selZ = static_cast<alu::Select::Select>(cf.expWord1.srcSelZ);
    exp->src.selW = static_cast<alu::Select::Select>(cf.expWord1.srcSelW);
 
-   exp->type = static_cast<exp::Type::Type>(cf.expWord0.type);
+   exp->type = static_cast<exp::Type::ExportType>(cf.expWord0.type);
    exp->elemSize = cf.expWord0.elemSize;
    exp->indexGpr = cf.expWord0.indexGpr;
    exp->wholeQuadMode = cf.expWord1.wholeQuadMode;

--- a/src/gpu/latte_decoder.cpp
+++ b/src/gpu/latte_decoder.cpp
@@ -331,6 +331,8 @@ decodeALU(DecodeState &state, cf::inst id, cf::Instruction &cf)
    case alu::inst::ALU_EXT:
       assert(false);
       break;
+   default:
+      break;
    }
 
    for (auto slot = 0u; slot <= cf.aluWord1.count; ) {
@@ -453,6 +455,8 @@ decodeALU(DecodeState &state, cf::inst id, cf::Instruction &cf)
                state.shader->code.emplace_back(push);
             }
             break;
+            default:
+               break;
             }
          }
 
@@ -516,6 +520,8 @@ decodeALU(DecodeState &state, cf::inst id, cf::Instruction &cf)
                state.shader->code.emplace_back(els);
             }
             break;
+            default:
+               break;
             }
          }
 
@@ -567,6 +573,8 @@ decodeALU(DecodeState &state, cf::inst id, cf::Instruction &cf)
       state.shader->code.emplace_back(pop2);
    }
    break;
+   default:
+      break;
    }
 
    return true;

--- a/src/gpu/latte_decoder.cpp
+++ b/src/gpu/latte_decoder.cpp
@@ -54,7 +54,7 @@ decode(Shader &shader, Shader::Type type, const gsl::span<uint8_t> &binary)
          decodeNormal(state, id, cf);
          break;
       case cf::Type::Export:
-         if (id == exp::EXP || id == exp::EXP_DONE) {
+         if (static_cast<exp::inst>(id) == exp::EXP || static_cast<exp::inst>(id) == exp::EXP_DONE) {
             decodeExport(state, id, cf);
          } else {
             assert(false);

--- a/src/gpu/latte_disassembler.cpp
+++ b/src/gpu/latte_disassembler.cpp
@@ -61,7 +61,7 @@ bool disassemble(std::string &out, const gsl::span<uint8_t> &binary)
          result &= disassembleNormal(state, id, cf);
          break;
       case cf::Type::Export:
-         if (id == exp::EXP || id == exp::EXP_DONE) {
+         if (static_cast<exp::inst>(id) == exp::EXP || static_cast<exp::inst>(id) == exp::EXP_DONE) {
             result &= disassembleExport(state, id, cf);
          } else {
             assert(false);

--- a/src/gpu/latte_disassembler.cpp
+++ b/src/gpu/latte_disassembler.cpp
@@ -391,7 +391,7 @@ bool disassembleExport(DisassembleState &state, cf::inst id, cf::Instruction &cf
 {
    auto eid = static_cast<exp::inst>(cf.expWord1.inst);
    auto name = exp::name[id];
-   auto type = static_cast<exp::Type::Type>(cf.expWord0.type);
+   auto type = static_cast<exp::Type::ExportType>(cf.expWord0.type);
 
    state.out
       << name

--- a/src/gpu/latte_opcodes.h
+++ b/src/gpu/latte_opcodes.h
@@ -178,11 +178,14 @@ namespace exp
 
 namespace Type
 {
-enum Type
+enum ExportType
 {
    Pixel          = 0,
    Position       = 1,
    Parameter      = 2,
+};
+enum WriteType
+{
    Write          = 0,
    WriteInd       = 1,
    WriteAck       = 2,

--- a/src/gpu/latte_shadir.h
+++ b/src/gpu/latte_shadir.h
@@ -206,7 +206,7 @@ struct ExportInstruction : Instruction
    latte::exp::inst id;
    SelRegister src;
    uint32_t dstReg = 0;
-   latte::exp::Type::Type type;
+   latte::exp::Type::ExportType type;
    uint32_t elemSize = 0;
    uint32_t indexGpr = 0;
    bool wholeQuadMode = false;

--- a/src/gpu/opengl/glsl_alu.cpp
+++ b/src/gpu/opengl/glsl_alu.cpp
@@ -29,6 +29,9 @@ void translateChannel(GenerateState &state, latte::alu::Channel::Channel channel
    case latte::alu::Channel::W:
       state.out << 'w';
       break;
+   case latte::alu::Channel::Unknown:
+      state.out << '?';
+      break;
    }
 }
 
@@ -80,6 +83,8 @@ void translateAluDestStart(GenerateState &state, AluInstruction *ins)
    case latte::alu::OutputModifier::Divide2:
       state.out << '(';
       break;
+   case latte::alu::OutputModifier::Off:
+      break;
    }
 
    if (ins->dest.clamp) {
@@ -102,6 +107,8 @@ void translateAluDestEnd(GenerateState &state, AluInstruction *ins)
       break;
    case latte::alu::OutputModifier::Divide2:
       state.out << ") / 2";
+      break;
+   case latte::alu::OutputModifier::Off:
       break;
    }
 
@@ -171,6 +178,9 @@ void translateAluSource(GenerateState &state, const AluSource &src)
       case AluSource::ConstantDouble:
          state.out << "int(";
          break;
+      case AluSource::ConstantInt:
+      case AluSource::ConstantLiteral:
+         break;
       }
    } else if (src.valueType == AluSource::Uint) {
       switch (src.type) {
@@ -199,6 +209,9 @@ void translateAluSource(GenerateState &state, const AluSource &src)
       case AluSource::ConstantFloat:
       case AluSource::ConstantDouble:
          state.out << "uint(";
+         break;
+      case AluSource::ConstantInt:
+      case AluSource::ConstantLiteral:
          break;
       }
    }
@@ -310,6 +323,12 @@ void translateAluSource(GenerateState &state, const AluSource &src)
    case AluSource::PreviousVector:
       state.out << '.';
       translateChannel(state, src.chan);
+   case AluSource::PreviousScalar:
+   case AluSource::ConstantFloat:
+   case AluSource::ConstantDouble:
+   case AluSource::ConstantInt:
+   case AluSource::ConstantLiteral:
+      break;
    }
 
    if (src.valueType == AluSource::Int || src.valueType == AluSource::Uint) {

--- a/src/gpu/opengl/glsl_tex.cpp
+++ b/src/gpu/opengl/glsl_tex.cpp
@@ -71,6 +71,7 @@ static bool translateSelect(GenerateState &state, latte::alu::Select::Select sel
    case latte::alu::Select::Mask:
    case latte::alu::Select::One:
    case latte::alu::Select::Zero:
+   case latte::alu::Select::Unknown:
       return false;
    }
 

--- a/src/hardwaretests.cpp
+++ b/src/hardwaretests.cpp
@@ -79,6 +79,8 @@ printTestField(Field field, Instruction instr, RegisterState *input, RegisterSta
    case Field::FPSCR:
       //gLog->debug("fpscr = {:08X} {:08x} {:08X}", input->fpscr.value, output->fpscr.value, state->fpscr.value);
       break;
+   default:
+      break;
    }
 }
 

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -51,6 +51,8 @@ getButtonMapping(vpad::Channel channel, vpad::Core button)
       return config::input::vpad0::button_home;
    case vpad::Core::Sync:
       return config::input::vpad0::button_sync;
+   case vpad::Core::Invalid:
+      return 0;
    }
 
    return 0;

--- a/src/modules/coreinit/coreinit_atomic64.cpp
+++ b/src/modules/coreinit/coreinit_atomic64.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "coreinit.h"
 #include "coreinit_atomic64.h"
 #include "coreinit_memheap.h"

--- a/src/modules/gx2/gx2_enum.h
+++ b/src/modules/gx2/gx2_enum.h
@@ -5,6 +5,10 @@
 #define GX2_ENUM(name, type) namespace name { enum Value : type {
 #endif
 
+#ifndef GX2_ENUM_WITH_RANGE
+#define GX2_ENUM_WITH_RANGE(name, type, min, max) namespace name { enum Range : type { First = min, Last = max }; enum Value : type {
+#endif
+
 #ifndef GX2_ENUM_END
 #define GX2_ENUM_END }; }
 #endif
@@ -13,16 +17,11 @@
 #define GX2_ENUM_VALUE(key, value) key = value,
 #endif
 
-#ifndef GX2_ENUM_VALID_RANGE
-#define GX2_ENUM_VALID_RANGE(min, max) First = min, Last = max,
-#endif
-
 GX2_ENUM(GX2AAMode, uint32_t)
    GX2_ENUM_VALUE(Mode1X, 0)
 GX2_ENUM_END
 
-GX2_ENUM(GX2AttribFormatType, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 0x1F)
+GX2_ENUM_WITH_RANGE(GX2AttribFormatType, uint32_t, 0, 0x1F)
    GX2_ENUM_VALUE(TYPE_8, 0x00)
    GX2_ENUM_VALUE(TYPE_4_4, 0x01)
    GX2_ENUM_VALUE(TYPE_16, 0x02)
@@ -52,8 +51,7 @@ GX2_ENUM(GX2AttribFormatFlags, uint32_t)
    GX2_ENUM_VALUE(SCALED, 0x800)
 GX2_ENUM_END
 
-GX2_ENUM(GX2AttribFormat, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 0xA0F)
+GX2_ENUM_WITH_RANGE(GX2AttribFormat, uint32_t, 0, 0xA0F)
 
    GX2_ENUM_VALUE(UNORM_8, 0x0)
    GX2_ENUM_VALUE(UNORM_8_8, 0x04)
@@ -77,14 +75,12 @@ GX2_ENUM(GX2AttribFormat, uint32_t)
    GX2_ENUM_VALUE(FLOAT_32_32_32_32, 0x813)
 GX2_ENUM_END
 
-GX2_ENUM(GX2AttribIndexType, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 1)
+GX2_ENUM_WITH_RANGE(GX2AttribIndexType, uint32_t, 0, 1)
    GX2_ENUM_VALUE(PerVertex, 0)
    GX2_ENUM_VALUE(PerInstance, 1)
 GX2_ENUM_END
 
-GX2_ENUM(GX2AlphaToMaskMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 4)
+GX2_ENUM_WITH_RANGE(GX2AlphaToMaskMode, uint32_t, 0, 4)
    GX2_ENUM_VALUE(NonDithered,   0)
    GX2_ENUM_VALUE(Dither0,       1)
    GX2_ENUM_VALUE(Dither90,      2)
@@ -92,8 +88,7 @@ GX2_ENUM(GX2AlphaToMaskMode, uint32_t)
    GX2_ENUM_VALUE(Dither270,     4)
 GX2_ENUM_END
 
-GX2_ENUM(GX2BlendMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 20)
+GX2_ENUM_WITH_RANGE(GX2BlendMode, uint32_t, 0, 20)
    GX2_ENUM_VALUE(Zero,             0)
    GX2_ENUM_VALUE(One,              1)
    GX2_ENUM_VALUE(SrcColor,         2)
@@ -115,8 +110,7 @@ GX2_ENUM(GX2BlendMode, uint32_t)
    GX2_ENUM_VALUE(InvSrc1Alpha,     18)
 GX2_ENUM_END
 
-GX2_ENUM(GX2BlendCombineMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 4)
+GX2_ENUM_WITH_RANGE(GX2BlendCombineMode, uint32_t, 0, 4)
    GX2_ENUM_VALUE(Add,              0)
    GX2_ENUM_VALUE(Subtract,         1)
    GX2_ENUM_VALUE(Min,              2)
@@ -124,12 +118,10 @@ GX2_ENUM(GX2BlendCombineMode, uint32_t)
    GX2_ENUM_VALUE(RevSubtract,      4)
 GX2_ENUM_END
 
-GX2_ENUM(GX2BufferingMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(1, 4)
+GX2_ENUM_WITH_RANGE(GX2BufferingMode, uint32_t, 1, 4)
 GX2_ENUM_END
 
-GX2_ENUM(GX2ChannelMask, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 15)
+GX2_ENUM_WITH_RANGE(GX2ChannelMask, uint32_t, 0, 15)
    GX2_ENUM_VALUE(R,    1)
    GX2_ENUM_VALUE(G,    2)
    GX2_ENUM_VALUE(RG,   3)
@@ -147,8 +139,7 @@ GX2_ENUM(GX2ChannelMask, uint32_t)
    GX2_ENUM_VALUE(RGBA, 15)
 GX2_ENUM_END
 
-GX2_ENUM(GX2CompareFunction, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 7)
+GX2_ENUM_WITH_RANGE(GX2CompareFunction, uint32_t, 0, 7)
    GX2_ENUM_VALUE(Never, 0)
    GX2_ENUM_VALUE(Less, 1)
    GX2_ENUM_VALUE(Equal, 2)
@@ -173,55 +164,47 @@ GX2_ENUM(GX2ClearFlags, uint32_t)
    GX2_ENUM_VALUE(Stencil, 2)
 GX2_ENUM_END
 
-GX2_ENUM(GX2DrcRenderMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 3)
+GX2_ENUM_WITH_RANGE(GX2DrcRenderMode, uint32_t, 0, 3)
    GX2_ENUM_VALUE(Disabled,      0)
    GX2_ENUM_VALUE(Single,        1)
 GX2_ENUM_END
 
-GX2_ENUM(GX2EndianSwapMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 3)
+GX2_ENUM_WITH_RANGE(GX2EndianSwapMode, uint32_t, 0, 3)
    GX2_ENUM_VALUE(None, 0)
    GX2_ENUM_VALUE(Swap8In16, 1)
    GX2_ENUM_VALUE(Swap8In32, 2)
    GX2_ENUM_VALUE(Default, 3)
 GX2_ENUM_END
 
-GX2_ENUM(GX2EventType, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 5)
+GX2_ENUM_WITH_RANGE(GX2EventType, uint32_t, 0, 5)
    GX2_ENUM_VALUE(Vsync, 2)
    GX2_ENUM_VALUE(Flip, 3)
    GX2_ENUM_VALUE(DisplayListOverrun, 4)
 GX2_ENUM_END
 
-GX2_ENUM(GX2FetchShaderType, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 3)
+GX2_ENUM_WITH_RANGE(GX2FetchShaderType, uint32_t, 0, 3)
    GX2_ENUM_VALUE(NoTessellation, 0)
    GX2_ENUM_VALUE(LineTessellation, 1)
    GX2_ENUM_VALUE(TriangleTessellation, 2)
    GX2_ENUM_VALUE(QuadTessellation, 3)
 GX2_ENUM_END
 
-GX2_ENUM(GX2FrontFace, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 1)
+GX2_ENUM_WITH_RANGE(GX2FrontFace, uint32_t, 0, 1)
    GX2_ENUM_VALUE(CounterClockwise, 0)
    GX2_ENUM_VALUE(Clockwise, 1)
 GX2_ENUM_END
 
-GX2_ENUM(GX2IndexType, uint32_t)
-   GX2_ENUM_VALID_RANGE(0x0, 0x9)
+GX2_ENUM_WITH_RANGE(GX2IndexType, uint32_t, 0x0, 0x9)
    GX2_ENUM_VALUE(U16_LE, 0x0)
    GX2_ENUM_VALUE(U32_LE, 0x1)
    GX2_ENUM_VALUE(U16, 0x4)
    GX2_ENUM_VALUE(U32, 0x9)
 GX2_ENUM_END
 
-GX2_ENUM(GX2InvalidateMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(1, 0x1ff)
+GX2_ENUM_WITH_RANGE(GX2InvalidateMode, uint32_t, 1, 0x1ff)
 GX2_ENUM_END
 
-GX2_ENUM(GX2LogicOp, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 0xff)
+GX2_ENUM_WITH_RANGE(GX2LogicOp, uint32_t, 0, 0xff)
    GX2_ENUM_VALUE(Clear,         0x00)
    GX2_ENUM_VALUE(Nor,           0x11)
    GX2_ENUM_VALUE(InvertedAnd,   0x22)
@@ -240,23 +223,20 @@ GX2_ENUM(GX2LogicOp, uint32_t)
    GX2_ENUM_VALUE(Set,           0xFF)
 GX2_ENUM_END
 
-GX2_ENUM(GX2PrimitiveMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0x1, 0x94)
+GX2_ENUM_WITH_RANGE(GX2PrimitiveMode, uint32_t, 0x1, 0x94)
    GX2_ENUM_VALUE(Triangles,        0x4)
    GX2_ENUM_VALUE(TriangleStrip,    0x6)
    GX2_ENUM_VALUE(Quads,            0x13)
    GX2_ENUM_VALUE(QuadStrip,        0x14)
 GX2_ENUM_END
 
-GX2_ENUM(GX2PolygonMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 2)
+GX2_ENUM_WITH_RANGE(GX2PolygonMode, uint32_t, 0, 2)
    GX2_ENUM_VALUE(Point,            0)
    GX2_ENUM_VALUE(Line,             1)
    GX2_ENUM_VALUE(Triangle,         2)
 GX2_ENUM_END
 
-GX2_ENUM(GX2RenderTarget, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 7)
+GX2_ENUM_WITH_RANGE(GX2RenderTarget, uint32_t, 0, 7)
    GX2_ENUM_VALUE(Target0, 0)
    GX2_ENUM_VALUE(Target1, 1)
    GX2_ENUM_VALUE(Target2, 2)
@@ -267,12 +247,10 @@ GX2_ENUM(GX2RenderTarget, uint32_t)
    GX2_ENUM_VALUE(Target7, 7)
 GX2_ENUM_END
 
-GX2_ENUM(GX2RoundingMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 1)
+GX2_ENUM_WITH_RANGE(GX2RoundingMode, uint32_t, 0, 1)
 GX2_ENUM_END
 
-GX2_ENUM(GX2ScanTarget, uint32_t)
-   GX2_ENUM_VALID_RANGE(1, 8)
+GX2_ENUM_WITH_RANGE(GX2ScanTarget, uint32_t, 1, 8)
    GX2_ENUM_VALUE(TV,      1)
    GX2_ENUM_VALUE(DRC,     4)
 GX2_ENUM_END
@@ -369,8 +347,7 @@ GX2_ENUM(GX2SurfaceUse, uint32_t)
    GX2_ENUM_VALUE(ScanBuffer,       1 << 3)
 GX2_ENUM_END
 
-GX2_ENUM(GX2StencilFunction, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 7)
+GX2_ENUM_WITH_RANGE(GX2StencilFunction, uint32_t, 0, 7)
    GX2_ENUM_VALUE(Keep, 0)
    GX2_ENUM_VALUE(Zero, 1)
    GX2_ENUM_VALUE(Replace, 2)
@@ -381,23 +358,20 @@ GX2_ENUM(GX2StencilFunction, uint32_t)
    GX2_ENUM_VALUE(DecrWrap, 7)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TessellationMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 2)
+GX2_ENUM_WITH_RANGE(GX2TessellationMode, uint32_t, 0, 2)
    GX2_ENUM_VALUE(Discrete, 0)
    GX2_ENUM_VALUE(Continuous, 1)
    GX2_ENUM_VALUE(Adaptive, 2)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexBorderType, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 3)
+GX2_ENUM_WITH_RANGE(GX2TexBorderType, uint32_t, 0, 3)
    GX2_ENUM_VALUE(TransparentBlack, 0)
    GX2_ENUM_VALUE(Black, 1)
    GX2_ENUM_VALUE(White, 2)
    GX2_ENUM_VALUE(Variable, 3)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexClampMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 7)
+GX2_ENUM_WITH_RANGE(GX2TexClampMode, uint32_t, 0, 7)
    GX2_ENUM_VALUE(Wrap, 0)
    GX2_ENUM_VALUE(Mirror, 1)
    GX2_ENUM_VALUE(Clamp, 2)
@@ -405,34 +379,28 @@ GX2_ENUM(GX2TexClampMode, uint32_t)
    GX2_ENUM_VALUE(ClampBorder, 6)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexMipFilterMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 2)
+GX2_ENUM_WITH_RANGE(GX2TexMipFilterMode, uint32_t, 0, 2)
    GX2_ENUM_VALUE(None, 0)
    GX2_ENUM_VALUE(Point, 1)
    GX2_ENUM_VALUE(Linear, 2)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexMipPerfMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 7)
+GX2_ENUM_WITH_RANGE(GX2TexMipPerfMode, uint32_t, 0, 7)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexXYFilterMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 1)
+GX2_ENUM_WITH_RANGE(GX2TexXYFilterMode, uint32_t, 0, 1)
    GX2_ENUM_VALUE(Point, 0)
    GX2_ENUM_VALUE(Linear, 1)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexAnisoRatio, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 4)
+GX2_ENUM_WITH_RANGE(GX2TexAnisoRatio, uint32_t, 0, 4)
    GX2_ENUM_VALUE(None, 0)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexZFilterMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 2)
+GX2_ENUM_WITH_RANGE(GX2TexZFilterMode, uint32_t, 0, 2)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TexZPerfMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 3)
+GX2_ENUM_WITH_RANGE(GX2TexZPerfMode, uint32_t, 0, 3)
 GX2_ENUM_END
 
 GX2_ENUM(GX2TileMode, uint32_t)
@@ -455,16 +423,14 @@ GX2_ENUM(GX2TileMode, uint32_t)
    GX2_ENUM_VALUE(LinearSpecial,    16)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TVRenderMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 5)
+GX2_ENUM_WITH_RANGE(GX2TVRenderMode, uint32_t, 0, 5)
    GX2_ENUM_VALUE(Standard480p,  1)
    GX2_ENUM_VALUE(Wide480p,      2)
    GX2_ENUM_VALUE(Wide720p,      3)
    GX2_ENUM_VALUE(Wide1080p,     5)
 GX2_ENUM_END
 
-GX2_ENUM(GX2TVScanMode, uint32_t)
-   GX2_ENUM_VALID_RANGE(0, 7)
+GX2_ENUM_WITH_RANGE(GX2TVScanMode, uint32_t, 0, 7)
    GX2_ENUM_VALUE(None, 0)
 GX2_ENUM_END
 
@@ -494,8 +460,8 @@ GX2_ENUM(GX2ShaderVarType, uint32_t)
 GX2_ENUM_END
 
 #undef GX2_ENUM
+#undef GX2_ENUM_WITH_RANGE
 #undef GX2_ENUM_END
 #undef GX2_ENUM_VALUE
-#undef GX2_ENUM_VALID_RANGE
 
 #endif

--- a/src/modules/gx2/gx2_enum_string.cpp
+++ b/src/modules/gx2/gx2_enum_string.cpp
@@ -1,9 +1,9 @@
 #include "gx2_enum_string.h"
 
 #define GX2_ENUM(name, type) std::string GX2EnumAsString(name ::Value enumValue) { switch (enumValue) {
+#define GX2_ENUM_WITH_RANGE(name, type, min, max) GX2_ENUM(name, type)
 #define GX2_ENUM_END default: return std::to_string(static_cast<int>(enumValue)); } }
 #define GX2_ENUM_VALUE(key, value) case value: return #key;
-#define GX2_ENUM_VALID_RANGE(key, value)
 
 #undef GX2_ENUM_H
 #include "gx2_enum.h"

--- a/src/modules/gx2/gx2_enum_string.h
+++ b/src/modules/gx2/gx2_enum_string.h
@@ -3,8 +3,8 @@
 #include "gx2_enum.h"
 
 #define GX2_ENUM(name, type) std::string GX2EnumAsString(name::Value enumValue);
+#define GX2_ENUM_WITH_RANGE(name, type, min, max) GX2_ENUM(name, type)
 #define GX2_ENUM_VALUE(key, value)
-#define GX2_ENUM_VALID_RANGE(min, max)
 #define GX2_ENUM_END
 
 #undef GX2_ENUM_H

--- a/src/modules/gx2/gx2_event.cpp
+++ b/src/modules/gx2/gx2_event.cpp
@@ -71,7 +71,7 @@ GX2SetEventCallback(GX2EventType::Value type, GX2EventCallbackFunction func, voi
       gLog->error("DisplayListOverrun callback set with no valid userData");
    }
 
-   if (type < GX2EventType::Last) {
+   if (static_cast<GX2EventType::Range>(type) < GX2EventType::Last) {
       gEventCallbacks[type].func = func;
       gEventCallbacks[type].data = userData;
    }
@@ -81,7 +81,7 @@ GX2SetEventCallback(GX2EventType::Value type, GX2EventCallbackFunction func, voi
 void
 GX2GetEventCallback(GX2EventType::Value type, be_GX2EventCallbackFunction *funcOut, be_ptr<void> *userDataOut)
 {
-   if (type < GX2EventType::Last) {
+   if (static_cast<GX2EventType::Range>(type) < GX2EventType::Last) {
       *funcOut = gEventCallbacks[type].func;
       *userDataOut = gEventCallbacks[type].data;
    } else {

--- a/src/modules/gx2/gx2_fetchshader.cpp
+++ b/src/modules/gx2/gx2_fetchshader.cpp
@@ -122,6 +122,8 @@ GX2FSCalcNumTessALUInsts(GX2FetchShaderType::Value type, GX2TessellationMode::Va
 {
    if (mode == GX2TessellationMode::Adaptive) {
       switch (type) {
+      case GX2FetchShaderType::NoTessellation:
+         break;
       case GX2FetchShaderType::LineTessellation:
          return 11;
       case GX2FetchShaderType::TriangleTessellation:
@@ -357,6 +359,8 @@ GX2InitFetchShaderEx(GX2FetchShader *fetchShader,
 
       if (tessMode == GX2TessellationMode::Adaptive) {
          switch (type) {
+         case GX2FetchShaderType::NoTessellation:
+            break;
          case GX2FetchShaderType::LineTessellation:
             numGPRs = 3;
             break;

--- a/src/modules/gx2/gx2_surface.cpp
+++ b/src/modules/gx2/gx2_surface.cpp
@@ -48,6 +48,7 @@ GX2CalcSurfaceSizeAndAlignment(GX2Surface *surface)
    size_t height_align = 1;
 
    switch (surface->tileMode) {
+   case GX2TileMode::Default:
    case GX2TileMode::LinearSpecial:
       break;
    case GX2TileMode::LinearAligned:


### PR DESCRIPTION
Fixes for various warnings reported by Clang.
The missing-case warnings in particular are probably a personal preference sort of thing; I've found them to be useful in the past, but if you think they're more clutter than they're worth, I can revert those changes and just build with -Wno-switch locally. I left a few of those alone where it was clear the logic was still being worked on or the fix would have been too awkward.