### PR TITLE
processor: Remove memset on CoreState struct instance

### DIFF
--- a/src/processor.h
+++ b/src/processor.h
@@ -38,7 +38,6 @@ struct Core
       id(id)
    {
       nextInterrupt = std::chrono::time_point<std::chrono::system_clock>::max();
-      std::memset(&state, 0, sizeof(cpu::CoreState));
    }
 
    uint32_t id;


### PR DESCRIPTION
CoreState consists of an atomic_bool which has it's own initializing constructor.