### PR TITLE
Print useful warnings for a couple of ELF errors

### DIFF
--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -608,6 +608,11 @@ Loader::processImports(LoadedModule *loadedMod, const SectionList &sections)
             continue;
          }
 
+         if (sym.shndx >= elf::SHN_LORESERVE) {
+            gLog->warn("Symbol {} in invalid section 0x{:X}", name, sym.shndx);
+            continue;
+         }
+
          // Calculate relocated address
          auto &impsec = sections[sym.shndx];
          auto offset = sym.value - impsec.header.addr;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -758,6 +758,10 @@ Loader::loadRPL(const std::string& name, const gsl::span<uint8_t> &data)
 
    // Read strtab
    auto shStrTab = reinterpret_cast<const char*>(sections[header.shstrndx].memory);
+   if (!shStrTab) {
+      gLog->error("Section name table missing");
+      return nullptr;
+   }
 
    // Calculate SDA Bases
    auto sdata = findSection(sections, shStrTab, ".sdata");


### PR DESCRIPTION
This avoids a couple of invalid pointer dereferences I ran into while trying to put together a simple RPX to test with.