### PR TITLE
Add implementation of __os_snprintf(), and fix string formatting.

### DIFF
--- a/src/modules/coreinit/coreinit_debug.cpp
+++ b/src/modules/coreinit/coreinit_debug.cpp
@@ -155,6 +155,14 @@ OSConsoleWrite(const char *msg, uint32_t unk)
    gLog->debug("OSConsoleWrite[{}] {}", unk, msg);
 }
 
+static int
+coreinit__os_snprintf(char *buffer, uint32_t size, const char *fmt, ppctypes::VarList& args)
+{
+   std::string str;
+   formatString(fmt, args, str);
+   return snprintf(buffer, size, "%s", str.c_str());
+}
+
 void
 CoreInit::registerDebugFunctions()
 {
@@ -165,4 +173,5 @@ CoreInit::registerDebugFunctions()
    RegisterKernelFunction(OSVReport);
    RegisterKernelFunction(COSWarn);
    RegisterKernelFunction(OSConsoleWrite);
+   RegisterKernelFunctionName("__os_snprintf", coreinit__os_snprintf);
 }

--- a/src/utils/strutils.h
+++ b/src/utils/strutils.h
@@ -88,28 +88,34 @@ ends_with(const std::string &source, const std::string &suffix)
 static inline std::string
 format_string(const char* fmt, ...)
 {
-   va_list args;
+   va_list args, args2;
    std::string ret;
+
    va_start(args, fmt);
+   va_copy(args2, args);
 
    // Calculate the size for our char buffer
 #ifdef PLATFORM_WINDOWS
-   int formatted_len = _vscprintf(fmt, args) + 1;
+   int formatted_len = _vscprintf(fmt, args2);
 #else
-   int formatted_len = vsnprintf(nullptr, 0, fmt, args);
+   int formatted_len = vsnprintf(nullptr, 0, fmt, args2);
 #endif
+   va_end(args2);
 
    if (formatted_len > 0) {
-      ret.resize(formatted_len);
+      // Reserve space for the trailing null as well (C++11 doesn't require
+      // that implementations include a trailing null element)
+      ret.resize(formatted_len + 1);
 
       // C++11 guarantees that strings are contiguous in memory
 #ifdef PLATFORM_WINDOWS
-      vsprintf_s(&ret[0], formatted_len, fmt, args);
+      vsprintf_s(&ret[0], formatted_len + 1, fmt, args);
 #else
-      vsnprintf(&ret[0], formatted_len, fmt, args);
+      vsnprintf(&ret[0], formatted_len + 1, fmt, args);
 #endif
    }
-
    va_end(args);
+
+   ret.resize(formatted_len);
    return ret;
 }


### PR DESCRIPTION
I put __os_snprintf() in coreinit_debug.cpp since there was already a string formatter there. I'm assuming __os_snprintf() behaves like C snprintf(), though I haven't tested it extensively.