### PR TITLE
Fix FPSCR behavior.

### DIFF
--- a/src/cpu/interpreter/interpreter_float.cpp
+++ b/src/cpu/interpreter/interpreter_float.cpp
@@ -519,9 +519,10 @@ fmaGeneric(ThreadState *state, Instruction instr)
    const double addend = (flags & FMASubtract) ? -b : b;
 
    const bool vxsnan = is_signalling_nan(a) || is_signalling_nan(b) || is_signalling_nan(c);
-   const bool vxisi = ((is_infinity(a) || is_infinity(c)) && is_infinity(b)
-                       && (std::signbit(a) ^ std::signbit(c)) != std::signbit(addend));
    const bool vximz = (is_infinity(a) && is_zero(c)) || (is_zero(a) && is_infinity(c));
+   const bool vxisi = (!vximz && !is_nan(a) && !is_nan(c)
+                       && (is_infinity(a) || is_infinity(c)) && is_infinity(b)
+                       && (std::signbit(a) ^ std::signbit(c)) != std::signbit(addend));
 
    const uint32_t oldFPSCR = state->fpscr.value;
    state->fpscr.vxsnan |= vxsnan;

--- a/src/cpu/interpreter/interpreter_float.cpp
+++ b/src/cpu/interpreter/interpreter_float.cpp
@@ -564,11 +564,14 @@ fmaGeneric(ThreadState *state, Instruction instr)
          state->fpr[instr.frD].paired1 = d;
       } else {
          state->fpr[instr.frD].value = d;
-         // Note that at least Intel Haswell CPUs have a bug in the FMA3
-         // instruction implementations which causes the underflow
-         // exception to not be raised if an FMA result is rounded up (in
-         // magnitude) to the minimum normal value, so the state of FPSCR
-         // will differ from the Espresso in such cases.
+         // Note that Intel CPUs report underflow based on the value _after_
+         // rounding, while the Espresso reports underflow _before_ rounding.
+         // (IEEE 754 allows an implementer to choose whether to report
+         // underflow before or after rounding, so both of these behaviors
+         // are technically compliant.)  Because of this, if an unrounded
+         // FMA result is slightly less in magnitude than the minimum normal
+         // value but is rounded to that value, the emulated FPSCR state will
+         // differ from a real Espresso in that the UX bit will not be set.
       }
 
       updateFPRF(state, d);

--- a/src/cpu/interpreter/interpreter_float.cpp
+++ b/src/cpu/interpreter/interpreter_float.cpp
@@ -428,7 +428,7 @@ fres(ThreadState *state, Instruction instr)
    } else {
       d = static_cast<float>(ppc_estimate_reciprocal(b));
       state->fpr[instr.frD].paired0 = d;
-      // paired1 is left undefined in the UISA.  TODO: Check actual behavior.
+      state->fpr[instr.frD].paired1 = d;
       updateFPRF(state, d);
       state->fpscr.zx |= zx;
       if (std::fetestexcept(FE_INEXACT)) {
@@ -737,6 +737,10 @@ frsp(ThreadState *state, Instruction instr)
    } else {
       auto d = static_cast<float>(b);
       state->fpr[instr.frD].paired0 = d;
+      // frD(ps1) is left undefined in the 750CL manual, but the processor
+      // actually copies the result to ps1 like other single-precision
+      // instructions.
+      state->fpr[instr.frD].paired1 = d;
       updateFPRF(state, d);
       updateFPSCR(state, oldFPSCR);
    }

--- a/src/cpu/interpreter/interpreter_float.cpp
+++ b/src/cpu/interpreter/interpreter_float.cpp
@@ -50,7 +50,7 @@ ppc_estimate_reciprocal(double v)
       return std::copysign(std::numeric_limits<float>::max(), v);
    }
 
-   if (bits.exponent > 1149) {
+   if (bits.exponent > 1150) {
       std::feraiseexcept(FE_UNDERFLOW | FE_INEXACT);
       return std::copysign(0.0, v);
    }

--- a/src/hardwaretests.cpp
+++ b/src/hardwaretests.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cfenv>
 #include <fstream>
 #include "cpu/cpu.h"
 #include "cpu/jit/jit.h"
@@ -173,6 +174,7 @@ bool runTests(const std::string &path)
          // Execute test
          mem::write(baseAddress, test.instr.value);
          cpu::jit::clearCache();
+         std::feclearexcept(FE_ALL_EXCEPT);
          cpu::executeSub(nullptr, &state);
 
          // Check XER (all bits)

--- a/src/hardwaretests.cpp
+++ b/src/hardwaretests.cpp
@@ -11,7 +11,8 @@
 #include "utils/strutils.h"
 #include "filesystem/filesystem.h"
 
-static const auto TEST_FPSCR = false;
+static const auto TEST_FPSCR = true;
+static const auto TEST_FPSCR_FR = false;
 
 namespace hwtest
 {
@@ -186,9 +187,15 @@ bool runTests(const std::string &path)
             failed = true;
          }
 
-         // Check FPSCR (all bits)
+         // Check FPSCR (all bits except possibly FR)
          if (TEST_FPSCR) {
-            if (state.fpscr.value != test.output.fpscr.value) {
+            auto state_fpscr = state.fpscr.value;
+            auto test_fpscr = test.output.fpscr.value;
+            if (!TEST_FPSCR_FR) {
+               state_fpscr &= ~0x00040000;
+               test_fpscr &= ~0x00040000;
+            }
+            if (state_fpscr != test_fpscr) {
                gLog->error("Test failed, fpscr {:08X} found {:08X}", test.output.fpscr.value, state.fpscr.value);
                failed = true;
             }


### PR DESCRIPTION
It turns out this was fairly non-intrusive; the only real additional complexity is VXISI for fmadd/etc and over/underflow on fres. I was actually able to simplify roundForMultiply() once I discovered that one of the causes of test failures was a bug in Intel's FPU (at least on the Haswell chip I have) causing FMA3 instructions to not raise the underflow exception in certain cases when they should.

There's also one minor result-affecting fix, which is that ppu_estimate_reciprocal() accepted too narrow an exponent range.

Ignoring FPSCR[FR], there are 26 hwtests that still fail. 2 of those are in fres, in which we don't set FPSCR[FI] on a non-over/underflow inaccurate result (to be fair, the manual says that fres leaves FI undefined). The other 24 are in fmsub and fnmsub and are caused by the Intel FPU bug; fmadd and fnmadd have the same issue, but none of the operand sets in the hwtests trigger the bug for those instructions. I doubt either problem will have any impact on real software.