### PR TITLE
Fix SDL build, and fix configuration defaults when GLFW is disabled.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -47,7 +47,13 @@ bool debug = false;
 namespace system
 {
 
+#if defined(DECAF_GLFW)
 std::string platform = "glfw";
+#elif defined(DECAF_SDL)
+std::string platform = "sdl";
+#else
+#error No UI backend selected!
+#endif
 std::string system_path = "/undefined_system_path";
 
 } // namespace system
@@ -59,7 +65,7 @@ namespace vpad0
 {
 
 std::string name = "keyboard";
-#ifdef _MSC_VER
+#if defined(DECAF_GLFW)
 int button_up = 265;
 int button_down = 264;
 int button_left = 263;
@@ -78,8 +84,8 @@ int button_plus = '1';
 int button_minus = '2';
 int button_home = '3';
 int button_sync = '4';
-#else
-int button_up = SDLK_U;
+#elif defined(DECAF_SDL)
+int button_up = SDLK_UP;
 int button_down = SDLK_DOWN;
 int button_left = SDLK_LEFT;
 int button_right = SDLK_RIGHT;

--- a/src/platform/platform_sdl_input.cpp
+++ b/src/platform/platform_sdl_input.cpp
@@ -33,7 +33,7 @@ PlatformSDL::getControllerHandle(const std::string &name)
          continue;
       }
 
-      if (name.compare(SDL_JoystickName(joystickData.handle)) == 0) {
+      if (name.compare(SDL_JoystickName(joystick)) == 0) {
          joystickData.handle = joystick;
          return mJoystickHandleStart + i;
       }


### PR DESCRIPTION
I saw you fixed getWindowBorderHeight(); there were just a couple other issues. I also set up config.cpp so it defaults to SDL if GLFW is disabled in the build.