### PR TITLE
Catch invalid memory accesses in emulated code

### DIFF
--- a/src/platform/platform_fiber.h
+++ b/src/platform/platform_fiber.h
@@ -7,6 +7,9 @@ namespace platform
 struct Fiber;
 using FiberEntryPoint = std::function<void(void *)>;
 
+// Magic value used in the access violation handler.
+static Fiber * const resumeCurrentFiber = reinterpret_cast<Fiber *>((uintptr_t)-1);
+
 Fiber *
 getThreadFiber();
 
@@ -18,5 +21,11 @@ destroyFiber(Fiber *fiber);
 
 void
 swapToFiber(Fiber *current, Fiber *target);
+
+// The handler should return a fiber to which to switch, the special value
+// resumeCurrentFiber to resume the current fiber, or null for the system
+// default behavior (program termination).
+bool
+installAccessViolationHandler(std::function<Fiber *(size_t)> handler);
 
 } // namespace platform

--- a/src/platform/platform_posix_fiber.cpp
+++ b/src/platform/platform_posix_fiber.cpp
@@ -1,8 +1,11 @@
 #include "platform.h"
 #include "platform_fiber.h"
+#include "utils/log.h"
 
 #ifdef PLATFORM_POSIX
 #include <array>
+#include <errno.h>
+#include <signal.h>
 #include <ucontext.h>
 
 namespace platform
@@ -18,6 +21,48 @@ struct Fiber
    void *entryParam = nullptr;
    std::array<char, DefaultStackSize> stack;
 };
+
+static std::function<Fiber *(size_t)> accessViolationHandler;
+static struct sigaction oldSegvHandler;
+static struct sigaction ourSegvHandler;  // Saved for segvHandler() to use.
+
+static void
+segvHandler(int unused_signum, siginfo_t *info, void *unused_context)
+{
+   Fiber *target = accessViolationHandler(reinterpret_cast<size_t>(info->si_addr));
+   if (target) {
+      // Reinstall the handler since SA_RESETHAND will have cleared it.
+      sigaction(SIGSEGV, &ourSegvHandler, nullptr);
+
+      if (target == resumeCurrentFiber) {
+         return;
+      } else {
+         setcontext(&target->context);
+      }
+   }
+
+   sigaction(SIGSEGV, &oldSegvHandler, nullptr);
+   // On return, the access will be retried, (presumably) causing another
+   // SIGSEGV which will this time go to the original handler.
+}
+
+bool
+installAccessViolationHandler(std::function<Fiber *(size_t)> handler)
+{
+   accessViolationHandler = handler;
+
+   ourSegvHandler.sa_sigaction = segvHandler;
+   sigemptyset(&ourSegvHandler.sa_mask);
+   // Set SA_RESETHAND so that a SEGV in the handler will terminate the
+   // program rather than going into an infinite loop.
+   ourSegvHandler.sa_flags = SA_SIGINFO | SA_RESETHAND;
+   if (sigaction(SIGSEGV, &ourSegvHandler, &oldSegvHandler) != 0) {
+      gLog->error("sigaction() failed: {}", strerror(errno));
+      return false;
+   }
+
+   return true;
+}
 
 Fiber *
 getThreadFiber()

--- a/src/platform/platform_win_fiber.cpp
+++ b/src/platform/platform_win_fiber.cpp
@@ -14,6 +14,13 @@ struct Fiber
    void *entryParam = nullptr;
 };
 
+bool
+installAccessViolationHandler(std::function<Fiber *(size_t)> handler)
+{
+   // TODO: not yet implemented
+   return true;
+}
+
 // handle = ConvertThreadToFiber and getcontext
 Fiber *
 getThreadFiber()

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -491,6 +491,21 @@ Processor::setInterruptTimer(uint32_t core, std::chrono::time_point<std::chrono:
    mTimerCondition.notify_all();
 }
 
+platform::Fiber *Processor::handleAccessViolation(ppcaddr_t address)
+{
+   if (!tCurrentCore || !tCurrentCore->threadId) {
+      return nullptr;
+   }
+
+   auto core = tCurrentCore;
+   auto fiber = core->currentFiber;
+
+   gLog->error("Access violation at address 0x{:x} on core {}, thread {}",
+               address, core->id, core->threadId);
+   fiber->thread->state = OSThreadState::Waiting;  // TODO: does this properly stop the thread?
+   return core->primaryFiberHandle;
+}
+
 namespace spdlog
 {
 namespace details

--- a/src/processor.h
+++ b/src/processor.h
@@ -99,6 +99,8 @@ public:
 
    void setInterruptTimer(uint32_t core, std::chrono::time_point<std::chrono::system_clock> when);
 
+   platform::Fiber *handleAccessViolation(ppcaddr_t address);
+
    // Core
    uint32_t getCoreID();
    uint32_t getCoreCount();


### PR DESCRIPTION
I've done this partly to make debugging easier, but also partly as groundwork for another change I'm looking to make which will support code that draws straight to the scan buffer (as my current test program does), by making scan buffers unwritable by default and using a write violation as an indication that the scan buffer memory needs to be copied to the host framebuffer. I am of course open to suggestions on alternate ways to accomplish that, but I figure it should be useful at least for simple experimentation.

@exjam: I don't know offhand what the Windows equivalent of ```sigaction(SIGSEGV, ...)``` is -- any chance you can take care of that? Also, I haven't dug into the details of the scheduler implementation so I'm not sure my code to stop an emulated thread is correct.