### PR TITLE
Fix SDL not consistently drawing to both TV and DRC windows.

### DIFF
--- a/src/platform/platform_sdl_ui.cpp
+++ b/src/platform/platform_sdl_ui.cpp
@@ -190,7 +190,9 @@ PlatformSDL::activateContext()
 void
 PlatformSDL::swapBuffers()
 {
+   SDL_GL_MakeCurrent(mTvWindow, mContext);
    SDL_GL_SwapWindow(mTvWindow);
+   SDL_GL_MakeCurrent(mDrcWindow, mContext);
    SDL_GL_SwapWindow(mDrcWindow);
 }
 


### PR DESCRIPTION
Just a quick thing I noticed while working on scan buffer read/write handling.