### PR TITLE
Fixed a minor bug during Debug mode compilation.

### DIFF
--- a/tools/gfd-tool/gfdtool.cpp
+++ b/tools/gfd-tool/gfdtool.cpp
@@ -640,7 +640,7 @@ printInfo(const std::string &filename)
          break;
       case gfd::BlockType::TextureHeader:
       {
-         assert(block.data.size() >= sizeof(GX2Texture));
+         assert(block.data.size() >= sizeof(gx2::GX2Texture));
 
          startGroup(out, "TextureHeader");
          {


### PR DESCRIPTION
- Namespace gx2:: was missing while referencing identifier GX2Texture in Debug assert.