### PR TITLE
Fix missing template instantiations and a couple of warnings

### DIFF
--- a/src/cpu/interpreter/interpreter_float.cpp
+++ b/src/cpu/interpreter/interpreter_float.cpp
@@ -161,6 +161,10 @@ updateFPRF(ThreadState *state, Type value)
    state->fpscr.fprf = flags;
 }
 
+// Make sure both float and double versions are available to other sources:
+template void updateFPRF(ThreadState *state, float value);
+template void updateFPRF(ThreadState *state, double value);
+
 void
 updateFloatConditionRegister(ThreadState *state)
 {

--- a/src/gpu/microcode/latte_disassembler_export.cpp
+++ b/src/gpu/microcode/latte_disassembler_export.cpp
@@ -50,7 +50,7 @@ disassembleExport(State &state, shadir::ExportInstruction *inst)
       state.out << ", ";
 
       if (inst->rw.rel == SQ_RELATIVE) {
-         state.out << "R[AL + " << inst->rw.id + "]";
+         state.out << "R[AL + " << inst->rw.id << "]";
       } else {
          state.out << "R" << inst->rw.id;
       }
@@ -61,8 +61,6 @@ disassembleExport(State &state, shadir::ExportInstruction *inst)
          << disassembleDestMask(inst->srcSel[1])
          << disassembleDestMask(inst->srcSel[2])
          << disassembleDestMask(inst->srcSel[3]);
-
-      inst->rw.rel;
    } else {
       // TODO: Disassemble export MEM_*
       state.out << " MEM_UNKNOWN_FORMAT";


### PR DESCRIPTION
I've been busy with other things, but just a couple of things I noticed when trying to build the current code. The updateFPRF() change is because recent Clang with -O2 seems to inline the double version of the function, so it's not available to the paired single instruction implementations.