### PR TITLE
Remove unnecessary usage of std::bind.

### DIFF
--- a/src/libcpu/src/cpu.cpp
+++ b/src/libcpu/src/cpu.cpp
@@ -9,7 +9,6 @@
 #include <atomic>
 #include <cfenv>
 #include <condition_variable>
-#include <functional>
 #include <memory>
 #include <vector>
 
@@ -115,14 +114,14 @@ start()
    for (auto i = 0; i < 3; ++i) {
       auto &core = gCore[i];
       core.id = i;
-      core.thread = std::thread(std::bind(&coreEntryPoint, &core));
+      core.thread = std::thread(coreEntryPoint, &core);
       core.next_alarm = std::chrono::time_point<std::chrono::system_clock>::max();
 
       static const std::string coreNames[] = { "Core #0", "Core #1", "Core #2" };
       platform::setThreadName(&core.thread, coreNames[core.id]);
    }
 
-   gTimerThread = std::thread(std::bind(&timerEntryPoint));
+   gTimerThread = std::thread(timerEntryPoint);
    platform::setThreadName(&gTimerThread, "Timer Thread");
 }
 

--- a/src/libdecaf/src/modules/coreinit/coreinit_fs.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_fs.cpp
@@ -135,7 +135,7 @@ startFsThread()
 {
    std::unique_lock<std::mutex> lock(sFsQueueMutex);
    sFsThreadRunning.store(true);
-   sFsThread = std::thread(std::bind(&fsThreadEntry));
+   sFsThread = std::thread(fsThreadEntry);
 }
 
 void


### PR DESCRIPTION
Because std::thread's constructors take copies of the arguments to be
used in the specified function, it is unnecessary to use std::bind to
bind the arguments of the functions to the function call.