### PR TITLE
Don't try to decrement past the beginning of a map.

### DIFF
--- a/src/libdecaf/src/debugger/debugger_analysis.cpp
+++ b/src/libdecaf/src/debugger/debugger_analysis.cpp
@@ -41,15 +41,17 @@ get(uint32_t address)
 
    if (sFuncData.size() > 0) {
       auto funcIter = sFuncData.upper_bound(address);
-      funcIter--;
-      if (funcIter != sFuncData.end()) {
-         auto &func = funcIter->second;
-         if (address >= func.start && address < func.end) {
-            // The function needs to have an end, or be the first two instructions
-            //  since we apply some special display logic to the first two instructions
-            //  in a never-ending function...
-            if (func.end != 0xFFFFFFFF || (address == func.start || address == func.start + 4)) {
-               info.func = &func;
+      if (funcIter != sFuncData.begin()) {
+         funcIter--;
+         if (funcIter != sFuncData.end()) {
+            auto &func = funcIter->second;
+            if (address >= func.start && address < func.end) {
+               // The function needs to have an end, or be the first two instructions
+               //  since we apply some special display logic to the first two instructions
+               //  in a never-ending function...
+               if (func.end != 0xFFFFFFFF || (address == func.start || address == func.start + 4)) {
+                  info.func = &func;
+               }
             }
          }
       }


### PR DESCRIPTION
This crashes with a null dereference on Linux with Clang/libc++.

It looks like the test against sFuncData.end() is a no-op, but I've left it alone just in case I'm missing something.