### PR TITLE
gx2: Allow unaligned surface height.

### DIFF
--- a/src/libdecaf/src/modules/gx2/gx2_surface.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_surface.cpp
@@ -236,7 +236,7 @@ GX2InitColorBufferRegs(GX2ColorBuffer *colorBuffer)
    // Update register values
    auto format = GX2GetSurfaceColorFormat(colorBuffer->surface.format);
    auto pitch = (colorBuffer->surface.pitch / latte::MicroTileWidth) - 1;
-   auto slice = ((colorBuffer->surface.pitch * colorBuffer->surface.height) / (latte::MicroTileWidth * latte::MicroTileHeight)) - 1;
+   auto slice = ((pitch + 1) * ((colorBuffer->surface.height + latte::MicroTileHeight - 1) / latte::MicroTileHeight)) - 1;
 
    cb_color_info = cb_color_info
       .FORMAT().set(format);


### PR DESCRIPTION
Xenoblade creates a number of surfaces on startup whose pixel count is less than MicroTileWidth * MicroTileHeight (64): for example, 8x4 R32G32F and 16x1 RGB565. For such surfaces, GX2InitColorBufferRegs computes a slice count of 0, tries to write -1U to the slice bitfield, and dies with an exception (value too large for bitfield). From a hardware design viewpoint, the most sensible behavior would be to simply round up the height to an integral multiple of the tile height when computing the slice count. But I haven't written any code to test whether this is in fact the correct behavior, so take this with a grain of salt.