### PR TITLE
Implement GX2DebugTagUserString functions

### DIFF
--- a/src/libdecaf/src/modules/gx2/gx2.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2.cpp
@@ -2,6 +2,7 @@
 #include "gx2_aperture.h"
 #include "gx2_clear.h"
 #include "gx2_contextstate.h"
+#include "gx2_debug.h"
 #include "gx2_display.h"
 #include "gx2_displaylist.h"
 #include "gx2_draw.h"
@@ -80,6 +81,10 @@ Module::RegisterFunctions()
    RegisterKernelFunction(GX2GetDisplayListWriteStatus);
    RegisterKernelFunction(GX2GetCurrentDisplayList);
    RegisterKernelFunction(GX2CopyDisplayList);
+
+   // Debug
+   //RegisterKernelFunction(GX2DebugTagUserString);
+   RegisterKernelFunction(GX2DebugTagUserStringVA);
 
    // Draw
    RegisterKernelFunction(GX2SetAttribBuffer);

--- a/src/libdecaf/src/modules/gx2/gx2_debug.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_debug.cpp
@@ -1,3 +1,4 @@
+#include "gx2_debug.h"
 #include "common/align.h"
 #include "common/log.h"
 #include "common/platform_dir.h"
@@ -276,6 +277,33 @@ GX2DebugDumpShader(GX2VertexShader *shader)
    GX2DebugDumpShader("shader_vertex_" + GX2PointerAsString(shader),
                       out.str(),
                       shader);
+}
+
+void
+GX2DebugTagUserString(GX2DebugTagUserStringType tagType, const char* fmtString, ...)
+{
+	std::string debugString("GX2DebugTagUserString:\t" "Type: ");
+
+	debugString.append(GX2DebugTagUserStringTypes[tagType]);
+	debugString.push_back('\t');
+	debugString.append(fmtString);
+
+	va_list argptr;
+	va_start(argptr, fmtString);
+	gLog->debug(debugString.c_str(), argptr);
+	va_end(argptr);
+}
+
+void
+GX2DebugTagUserStringVA(GX2DebugTagUserStringType tagType, const char* fmtString, va_list args)
+{
+	std::string debugString("GX2DebugTagUserStringVA:\t" "Type: ");
+
+	debugString.append(GX2DebugTagUserStringTypes[tagType]);
+	debugString.push_back('\t');
+	debugString.append(fmtString);
+
+	gLog->debug(debugString.c_str(), args);
 }
 
 namespace internal

--- a/src/libdecaf/src/modules/gx2/gx2_debug.h
+++ b/src/libdecaf/src/modules/gx2/gx2_debug.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "gx2_enum.h"
 
 namespace gx2
 {
@@ -8,6 +9,13 @@ struct GX2Texture;
 struct GX2FetchShader;
 struct GX2PixelShader;
 struct GX2VertexShader;
+
+const char * const GX2DebugTagUserStringTypes[] = {
+	"Indent",
+	"Undent",
+	"Comment",
+	"Bookmark"
+};
 
 void
 GX2DebugDumpTexture(const GX2Texture *texture);
@@ -20,6 +28,12 @@ GX2DebugDumpShader(GX2PixelShader *shader);
 
 void
 GX2DebugDumpShader(GX2VertexShader *shader);
+
+void
+GX2DebugTagUserString(GX2DebugTagUserStringType tagType, const char *fmtString, ...);
+
+void
+GX2DebugTagUserStringVA(GX2DebugTagUserStringType tagType, const char* fmtString, va_list args);
 
 namespace internal
 {

--- a/src/libdecaf/src/modules/gx2/gx2_enum.h
+++ b/src/libdecaf/src/modules/gx2/gx2_enum.h
@@ -162,6 +162,13 @@ ENUM_BEG(GX2ClearFlags, uint32_t)
    ENUM_VALUE(Stencil,              2)
 ENUM_END(GX2ClearFlags)
 
+ENUM_BEG(GX2DebugTagUserStringType, uint32_t)
+	ENUM_VALUE(Indent,				0)
+	ENUM_VALUE(Undent,				1)
+	ENUM_VALUE(Comment,				2)
+	ENUM_VALUE(Bookmark,			3)
+ENUM_END(GX2DebugTagUserStringType)
+
 ENUM_BEG(GX2DrcRenderMode, uint32_t)
    ENUM_VALUE(Disabled,             0)
    ENUM_VALUE(Single,               1)


### PR DESCRIPTION
Kernel functions with variable arguments aren't implemented yet so I
couldn't register the one that uses them, but the functions are done.
Only game I've seen them used in is Super Meat Boy (but I do only have like 10).