### PR TITLE
opengl: Separate shader PV/PS updates from register writes.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/glsl2_alu.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_alu.cpp
@@ -467,13 +467,6 @@ insertDestBegin(fmt::MemoryWriter &out,
       flags = getInstructionFlags(inst.op3.ALU_INST());
    }
 
-   if (writeMask) {
-      auto gpr = inst.word1.DST_GPR().get();
-      out << "R[" << gpr << "].";
-      insertChannel(out, inst.word1.DST_CHAN());
-      out << " = ";
-   }
-
    if (flags & SQ_ALU_FLAG_INT_OUT) {
       out << "intBitsToFloat(";
    } else if (flags & SQ_ALU_FLAG_UINT_OUT) {

--- a/src/libdecaf/src/gpu/opengl/glsl2_alu_reduction.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_alu_reduction.cpp
@@ -197,24 +197,6 @@ CUBE(State &state, const ControlFlowInst &cf, const std::array<AluInst, 4> &grou
    insertLineStart(state);
    state.out << "}";
    insertLineEnd(state);
-
-   // If any instructions write to a register, copy appropriately from PVo
-   char srcMaskBuf[5], dstMaskBuf[5];
-   int maskPos = 0;
-   for (auto i = 0u; i < group.size(); ++i) {
-      if (group[i].op2.WRITE_MASK()) {
-         srcMaskBuf[maskPos] = "xyzw"[i];
-         dstMaskBuf[maskPos] = "xyzw"[group[i].word1.DST_CHAN()];
-         maskPos++;
-      }
-   }
-   if (maskPos > 0) {
-      srcMaskBuf[maskPos] = '\0';
-      dstMaskBuf[maskPos] = '\0';
-      insertLineStart(state);
-      state.out << "R[" << group[0].word1.DST_GPR().get() << "]." << dstMaskBuf << " = PVo." << srcMaskBuf << ";";
-      insertLineEnd(state);
-   }
 }
 
 static void

--- a/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
@@ -1,6 +1,7 @@
 #include "common/decaf_assert.h"
 #include "common/log.h"
 #include "glsl2_translate.h"
+#include "glsl2_alu.h"
 #include "glsl2_cf.h"
 #include "gpu/microcode/latte_instructions.h"
 #include "gpu/microcode/latte_decoders.h"
@@ -256,6 +257,7 @@ translateControlFlowALU(State &state, const ControlFlowInst &cf)
       auto didReduction = false;
       auto updatePreviousVector = false;
       auto updatePreviousScalar = false;
+      std::vector<std::string> destWrites;
       state.literals = group.literals;
 
       for (auto j = 0u; j < group.instructions.size(); ++j) {
@@ -265,6 +267,48 @@ translateControlFlowALU(State &state, const ControlFlowInst &cf)
          auto flags = SQ_ALU_FLAG_NONE;
          const char *name = nullptr;
          state.unit = unit;
+
+         bool writeMask = true;
+         if (inst.word1.ENCODING() == SQ_ALU_OP2) {
+            if (inst.op2.ALU_INST() == latte::SQ_OP2_INST_MOVA_INT
+             || inst.op2.ALU_INST() == latte::SQ_OP2_INST_MOVA_FLOOR) {
+               writeMask = false;  // These don't write through PV.
+            } else {
+               writeMask = inst.op2.WRITE_MASK();
+            }
+         }
+         if (writeMask) {
+            fmt::MemoryWriter writeBuf;
+            auto gpr = inst.word1.DST_GPR().get();
+            writeBuf << "R[" << gpr << "].";
+            latte::SQ_CHAN writeUnit = inst.word1.DST_CHAN();
+            if (inst.word1.ENCODING() == SQ_ALU_OP2
+                && (inst.op2.ALU_INST() == latte::SQ_OP2_INST_DOT4
+                 || inst.op2.ALU_INST() == latte::SQ_OP2_INST_DOT4_IEEE)) {
+               // Special case: DOT4 instructions always write to X.
+               writeUnit = SQ_CHAN_X;
+            }
+            insertChannel(writeBuf, writeUnit);
+            writeBuf << " = ";
+            switch (unit) {
+            case SQ_CHAN_X:
+               writeBuf << "PVo.x;";
+               break;
+            case SQ_CHAN_Y:
+               writeBuf << "PVo.y;";
+               break;
+            case SQ_CHAN_Z:
+               writeBuf << "PVo.z;";
+               break;
+            case SQ_CHAN_W:
+               writeBuf << "PVo.w;";
+               break;
+            case SQ_CHAN_T:
+               writeBuf << "PSo;";
+               break;
+            }
+            destWrites.push_back(writeBuf.str());
+         }
 
          // Process all reduction instructions once as a group
          if (isReductionInstruction(inst)) {
@@ -315,6 +359,12 @@ translateControlFlowALU(State &state, const ControlFlowInst &cf)
          if (func) {
             func(state, cf, inst);
          }
+      }
+
+      for (auto writeStmt : destWrites) {
+         insertLineStart(state);
+         state.out << writeStmt;
+         insertLineEnd(state);
       }
 
       if (updatePreviousVector) {


### PR DESCRIPTION
Xenoblade has a shader with this ALU group:
```
   31 x: MUL             R125.x, R127.x, C6.w
      y: MUL             R125.y, R127.y, C6.w
      z: MUL             R126.z, R127.z, C6.w
      w: MULADD          R126.w, C7.z, R3.w, R126.w
      t: MULADD          R125.z, C7.z, R3.z, R126.z VEC_120
```
R126.z is both an output (in unit z) and an input (in unit t), but since these are translated to sequential GLSL statements, R126.z is clobbered before the unit t instruction has a chance to read the previous value. The operation sequence involving R126.z transforms Y coordinates from local to device space, and this bug causes a +1 on the output Y coordinates to be lost; the visible result is that a black quad intended to cover the entire framebuffer (Y=[-1,+1]) instead only covers the bottom half (Y=[-2,0]), leaving the top half white.