### PR TITLE
debugger: Properly select the interrupting thread on pause.

### DIFF
--- a/src/libdecaf/src/debugger/debugger_ui_draw.cpp
+++ b/src/libdecaf/src/debugger/debugger_ui_draw.cpp
@@ -106,6 +106,13 @@ uint32_t getThreadStack(coreinit::OSThread *thread)
 }
 
 void
+setActiveCore(int id)
+{
+   decaf_check(!sActiveThread);
+   sActiveCore = id;
+}
+
+void
 setActiveThread(coreinit::OSThread *thread)
 {
    decaf_check(sIsPaused);

--- a/src/libdecaf/src/debugger/debugger_ui_internal.h
+++ b/src/libdecaf/src/debugger/debugger_ui_internal.h
@@ -26,6 +26,9 @@ coreinit::OSThread *
 getActiveThread();
 
 void
+setActiveCore(int id);
+
+void
 setActiveThread(coreinit::OSThread *thread);
 
 cpu::CoreRegs *


### PR DESCRIPTION
The debugger still doesn't select the thread with the breakpoint/exception correctly because it never records which core initiated the pause (it looks like there was a variable intended for that purpose, but it was never used anywhere). This should get things working in all cases.