### PR TITLE
opengl: Use separate framebuffer objects for clear operations.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
@@ -286,19 +286,17 @@ GLDriver::decafClearColor(const pm4::DecafClearColor &data)
    auto buffer = getColorBuffer(cb_color_base, data.cb_color_size, data.cb_color_info);
 
    // Bind color buffer
-   gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_COLOR_ATTACHMENT0, buffer->object, 0);
+   gl::glNamedFramebufferTexture(mColorClearFrameBuffer, gl::GL_COLOR_ATTACHMENT0, buffer->object, 0);
+   gl::GLenum status = gl::glCheckNamedFramebufferStatus(mColorClearFrameBuffer, gl::GL_DRAW_FRAMEBUFFER);
+   if (status != gl::GL_FRAMEBUFFER_COMPLETE) {
+      gLog->warn("Skipping clear with invalid color buffer.");
+      return;
+   }
 
    // Clear color buffer
    gl::glDisable(gl::GL_SCISSOR_TEST);
-   gl::glClearBufferfv(gl::GL_COLOR, 0, colors);
+   gl::glClearNamedFramebufferfv(mColorClearFrameBuffer, gl::GL_COLOR, 0, colors);
    gl::glEnable(gl::GL_SCISSOR_TEST);
-
-   // Restore original color buffer
-   if (mActiveColorBuffers[0]) {
-      gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_COLOR_ATTACHMENT0, mActiveColorBuffers[0]->object, 0);
-   } else {
-      gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_COLOR_ATTACHMENT0, 0, 0);
-   }
 }
 
 void
@@ -312,19 +310,17 @@ GLDriver::decafClearDepthStencil(const pm4::DecafClearDepthStencil &data)
    auto buffer = getDepthBuffer(db_depth_base, data.db_depth_size, data.db_depth_info);
 
    // Bind depth buffer
-   gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_DEPTH_ATTACHMENT, buffer->object, 0);
+   gl::glNamedFramebufferTexture(mDepthClearFrameBuffer, gl::GL_DEPTH_ATTACHMENT, buffer->object, 0);
+   gl::GLenum status = gl::glCheckNamedFramebufferStatus(mColorClearFrameBuffer, gl::GL_DRAW_FRAMEBUFFER);
+   if (status != gl::GL_FRAMEBUFFER_COMPLETE) {
+      gLog->warn("Skipping clear with invalid depth buffer.");
+      return;
+   }
 
    // Clear depth buffer
    gl::glDisable(gl::GL_SCISSOR_TEST);
-   gl::glClearBufferfi(gl::GL_DEPTH_STENCIL, 0, db_depth_clear.DEPTH_CLEAR, db_stencil_clear.CLEAR());
+   gl::glClearNamedFramebufferfi(mDepthClearFrameBuffer, gl::GL_DEPTH_STENCIL, 0, db_depth_clear.DEPTH_CLEAR, db_stencil_clear.CLEAR());
    gl::glEnable(gl::GL_SCISSOR_TEST);
-
-   // Restore original depth buffer
-   if (mActiveDepthBuffer) {
-      gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_DEPTH_ATTACHMENT, mActiveDepthBuffer->object, 0);
-   } else {
-      gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_DEPTH_ATTACHMENT, 0, 0);
-   }
 }
 
 } // namespace opengl

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -33,6 +33,10 @@ void GLDriver::initGL()
    // Create our default framebuffer
    gl::glGenFramebuffers(1, &mFrameBuffer);
    gl::glBindFramebuffer(gl::GL_FRAMEBUFFER, mFrameBuffer);
+
+   // Create framebuffers for color-clear and depth-clear operations
+   gl::glCreateFramebuffers(1, &mColorClearFrameBuffer);
+   gl::glCreateFramebuffers(1, &mDepthClearFrameBuffer);
 }
 
 void GLDriver::decafSetBuffer(const pm4::DecafSetBuffer &data)

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -281,6 +281,8 @@ private:
 
    gl::GLuint mBlitFrameBuffers[2];
    gl::GLuint mFrameBuffer;
+   gl::GLuint mColorClearFrameBuffer;
+   gl::GLuint mDepthClearFrameBuffer;
    Shader *mActiveShader = nullptr;
    SurfaceBuffer *mActiveDepthBuffer = nullptr;
    std::array<SurfaceBuffer *, MAX_COLOR_BUFFER_COUNT> mActiveColorBuffers;


### PR DESCRIPTION
I noticed this in the process of tracking down why Xenoblade only renders some primitives to the left 768 pixels of the TV screen. This patch doesn't solve that original problem, but it does fix some cases of depth buffers not being fully cleared because a smaller color buffer happened to be attached to GL_FRAMEBUFFER at the same time.