### PR TITLE
opengl: Disable color buffers which are masked off at draw time.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
@@ -12,11 +12,15 @@ namespace opengl
 
 bool GLDriver::checkActiveColorBuffer()
 {
-   for (auto i = 0u; i < mActiveColorBuffers.size(); ++i) {
+   auto cb_target_mask = getRegister<latte::CB_TARGET_MASK>(latte::Register::CB_TARGET_MASK);
+   auto cb_shader_mask = getRegister<latte::CB_SHADER_MASK>(latte::Register::CB_SHADER_MASK);
+   auto mask = cb_target_mask.value & cb_shader_mask.value;
+
+   for (auto i = 0u; i < mActiveColorBuffers.size(); ++i, mask >>= 4) {
       auto cb_color_base = getRegister<latte::CB_COLORN_BASE>(latte::Register::CB_COLOR0_BASE + i * 4);
       auto &active = mActiveColorBuffers[i];
 
-      if (!cb_color_base.BASE_256B) {
+      if (!cb_color_base.BASE_256B || !(mask & 0xF)) {
          if (active) {
             // Unbind color buffer i
             gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_COLOR_ATTACHMENT0 + i, 0, 0);


### PR DESCRIPTION
I'm not at all confident this is the "correct" fix (the GPU might just be fine with drawing to different-sized color buffers simultaneously, which would make things difficult in OpenGL land), but this fixes the Xenoblade boot screen getting cropped due to extra 768x624 color buffers which are masked off by CB_SHADER_MASK at draw time.

FWIW, Xenoblade never seems to call GX2SetColorBuffer with a null buffer address, and it has one function which roughly looks like:
```
void myGX2SetColorBuffer1(GX2ColorBuffer *cb) {
   if (cb) {
      GX2SetColorBuffer(cb, 1);
      GX2SetTargetChannelMasks(15, 15, 0, 0, 0, 0, 0, 0);
   } else {
      GX2SetTargetChannelMasks(15, 0, 0, 0, 0, 0, 0, 0);
   }
}
```
suggesting that masking off a color target is in fact equivalent to setting it to null.