### PR TITLE
libcpu: Fix debugger selecting wrong core on breakpoint.

### DIFF
--- a/src/libcpu/src/cpu_interrupts.cpp
+++ b/src/libcpu/src/cpu_interrupts.cpp
@@ -101,14 +101,6 @@ checkInterrupts()
 
    // Check if we hit any breakpoints
    if (popBreakpoint(core->nia)) {
-      // Need to interrupt all the other cores
-      for (auto i = 0; i < 3; ++i) {
-         if (i != core->id) {
-            interrupt(i, DBGBREAK_INTERRUPT);
-         }
-      }
-
-      // Our core we can just add it to the local interrupt list
       flags |= DBGBREAK_INTERRUPT;
    }
 


### PR DESCRIPTION
There is no need to interrupt other cores from libcpu, since the debugger will do so on its own.