### PR TITLE
coreinit: Enable locked cache DMA by default.

### DIFF
--- a/src/libdecaf/src/modules/coreinit/coreinit_lockedcache.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_lockedcache.cpp
@@ -197,7 +197,7 @@ void
 Module::initialiseLockedCache()
 {
    auto base = reinterpret_cast<uint8_t *>(mem::translate(mem::LockedCacheBase));
-   sDMAEnabled.fill(false);
+   sDMAEnabled.fill(true);
 
    for (auto i = 0u; i < CoreCount; ++i) {
       sLockedCache[i] = new TeenyHeap(base + (sLockedCacheSize * i), sLockedCacheSize);


### PR DESCRIPTION
Xenoblade never calls LCEnableDMA() (the rpx doesn't even reference it, for that matter) but uses LC{Load,Store}DMABlocks() for block copies.