### PR TITLE
opengl: Fix disassembly of VTX_FETCH instructions in shader comments.

### DIFF
--- a/src/libdecaf/src/gpu/microcode/latte_disassembler.h
+++ b/src/libdecaf/src/gpu/microcode/latte_disassembler.h
@@ -75,7 +75,7 @@ void
 disassembleVtxInstruction(fmt::MemoryWriter &out,
                           const latte::ControlFlowInst &parent,
                           const VertexFetchInst &tex,
-                          int namePad);
+                          int namePad = 0);
 
 void
 disassembleTexInstruction(fmt::MemoryWriter &out,

--- a/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
@@ -57,7 +57,12 @@ translateTEX(State &state, const ControlFlowInst &cf)
 
       insertLineStart(state);
       state.out.write("// {:02} ", state.groupPC);
-      latte::disassembler::disassembleTexInstruction(state.out, cf, tex);
+      if (id == SQ_TEX_INST_VTX_FETCH || id == SQ_TEX_INST_VTX_SEMANTIC) {
+         auto vtx = *reinterpret_cast<const VertexFetchInst *>(&tex);
+         latte::disassembler::disassembleVtxInstruction(state.out, cf, vtx);
+      } else {
+         latte::disassembler::disassembleTexInstruction(state.out, cf, tex);
+      }
       insertLineEnd(state);
 
       if (itr != sInstructionMapTEX.end()) {


### PR DESCRIPTION
The emulator still dies because it can't translate VTX_FETCH, but one step at a time...