### PR TITLE
Store configuration files in a platform-standard directory.

### DIFF
--- a/src/common/platform_dir.h
+++ b/src/common/platform_dir.h
@@ -8,6 +8,9 @@ bool
 createDirectory(const std::string &path);
 
 bool
+createParentDirectories(const std::string &path);
+
+bool
 fileExists(const std::string &path);
 
 bool
@@ -15,5 +18,8 @@ isFile(const std::string &path);
 
 bool
 isDirectory(const std::string &path);
+
+std::string
+getConfigDirectory();
 
 } // namespace platform

--- a/src/common/src/platform_posix_dir.cpp
+++ b/src/common/src/platform_posix_dir.cpp
@@ -1,7 +1,10 @@
 #include "platform.h"
 #include "platform_dir.h"
+#include "strutils.h"
 
 #ifdef PLATFORM_POSIX
+#include <errno.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -11,7 +14,23 @@ namespace platform
 bool
 createDirectory(const std::string &path)
 {
-   return mkdir(path.c_str(), 0755) == 0;
+   if (!createParentDirectories(path)) {
+      return false;
+   }
+
+   return mkdir(path.c_str(), 0755) == 0
+      || (errno == EEXIST && isDirectory(path));
+}
+
+bool
+createParentDirectories(const std::string &path)
+{
+   auto slashPos = path.rfind('/');
+   if (slashPos == std::string::npos || slashPos == 0) {
+      return true;
+   }
+
+   return createDirectory(path.substr(0, slashPos));
 }
 
 bool
@@ -44,6 +63,18 @@ isDirectory(const std::string &path)
    }
 
    return S_ISDIR(info.st_mode);
+}
+
+std::string
+getConfigDirectory()
+{
+   // TODO: will be different for Mac
+   const char *home = getenv("HOME");
+   if (home && *home) {
+      return format_string("%s/.config", home);
+   } else {
+      return ".";
+   }
 }
 
 } // namespace platform

--- a/src/decaf-cli/main.cpp
+++ b/src/decaf-cli/main.cpp
@@ -94,7 +94,8 @@ start(excmd::parser &parser,
    }
 
    // First thing, load the config!
-   config::load("cli_config.json");
+   decaf::createConfigDirectory();
+   config::load(decaf::makeConfigPath("cli_config.json"));
 
    // Allow command line options to override config
    if (options.has("jit-debug")) {

--- a/src/decaf-cli/main.cpp
+++ b/src/decaf-cli/main.cpp
@@ -27,6 +27,10 @@ getCommandLineParser()
    parser.add_command("help")
       .add_argument("help-command", optional {}, value<std::string> {});
 
+   auto config_options = parser.add_option_group("Configuration Options")
+      .add_option("config", description { "Specify path to configuration file." },
+                  value<std::string> {});
+
    auto jit_options = parser.add_option_group("JIT Options")
       .add_option("jit", description { "Enables the JIT engine." })
       .add_option("jit-debug", description { "Verify JIT implementation against interpreter." });
@@ -47,6 +51,7 @@ getCommandLineParser()
       .add_option("timeout_ms", description { "How long to execute the game for before quitting." }, value<uint32_t> {});
 
    parser.add_command("play")
+      .add_option_group(config_options)
       .add_option_group(jit_options)
       .add_option_group(log_options)
       .add_option_group(sys_options)
@@ -94,8 +99,14 @@ start(excmd::parser &parser,
    }
 
    // First thing, load the config!
-   decaf::createConfigDirectory();
-   config::load(decaf::makeConfigPath("cli_config.json"));
+   std::string configPath;
+   if (options.has("config")) {
+      configPath = options.get<std::string>("config");
+   } else {
+      decaf::createConfigDirectory();
+      configPath = decaf::makeConfigPath("cli_config.json");
+   }
+   config::load(configPath);
 
    // Allow command line options to override config
    if (options.has("jit-debug")) {

--- a/src/decaf-sdl/main.cpp
+++ b/src/decaf-sdl/main.cpp
@@ -28,6 +28,10 @@ getCommandLineParser()
    parser.add_command("help")
       .add_argument("help-command", optional {}, value<std::string> {});
 
+   auto config_options = parser.add_option_group("Configuration Options")
+      .add_option("config", description { "Specify path to configuration file." },
+                  value<std::string> {});
+
    auto jit_options = parser.add_option_group("JIT Options")
       .add_option("jit", description { "Enables the JIT engine." })
       .add_option("jit-debug", description { "Verify JIT implementation against interpreter." });
@@ -46,6 +50,7 @@ getCommandLineParser()
       .add_option("sys-path", description { "Where to locate any external system files." }, value<std::string> {});
 
    parser.add_command("play")
+      .add_option_group(config_options)
       .add_option_group(jit_options)
       .add_option_group(log_options)
       .add_option_group(sys_options)
@@ -93,8 +98,14 @@ start(excmd::parser &parser,
    }
 
    // First thing, load the config!
-   decaf::createConfigDirectory();
-   config::load(decaf::makeConfigPath("config.json"));
+   std::string configPath;
+   if (options.has("config")) {
+      configPath = options.get<std::string>("config");
+   } else {
+      decaf::createConfigDirectory();
+      configPath = decaf::makeConfigPath("config.json");
+   }
+   config::load(configPath);
 
    // Allow command line options to override config
    if (options.has("jit-debug")) {

--- a/src/decaf-sdl/main.cpp
+++ b/src/decaf-sdl/main.cpp
@@ -93,7 +93,8 @@ start(excmd::parser &parser,
    }
 
    // First thing, load the config!
-   config::load("config.json");
+   decaf::createConfigDirectory();
+   config::load(decaf::makeConfigPath("config.json"));
 
    // Allow command line options to override config
    if (options.has("jit-debug")) {

--- a/src/libdecaf/decaf.h
+++ b/src/libdecaf/decaf.h
@@ -11,6 +11,12 @@
 namespace decaf
 {
 
+std::string
+makeConfigPath(const std::string &filename);
+
+bool
+createConfigDirectory();
+
 void
 initialiseLogging(std::vector<spdlog::sink_ptr> &sinks,
                   spdlog::level::level_enum level);

--- a/src/libdecaf/src/debugger/debugger_ui_opengl.cpp
+++ b/src/libdecaf/src/debugger/debugger_ui_opengl.cpp
@@ -2,7 +2,9 @@
 #include <glbinding/Binding.h>
 #include <gsl.h>
 #include <imgui.h>
+#include "common/platform_dir.h"
 #include "debugger/debugger_ui.h"
+#include "decaf.h"
 #include "decaf_debugger.h"
 
 namespace decaf
@@ -30,6 +32,9 @@ struct DebugDrawData
 static DebugDrawData
 sDebugDrawData;
 
+static std::string
+sConfigPath;
+
 void
 initialise()
 {
@@ -41,6 +46,9 @@ initialiseUiGL()
 {
    auto &data = sDebugDrawData;
    ImGuiIO& io = ImGui::GetIO();
+
+   sConfigPath = makeConfigPath("imgui.ini");
+   io.IniFilename = sConfigPath.c_str();
 
    const gl::GLchar *vertex_shader =
       "#version 330\n"

--- a/src/libdecaf/src/decaf.cpp
+++ b/src/libdecaf/src/decaf.cpp
@@ -50,6 +50,18 @@ public:
    }
 };
 
+std::string
+makeConfigPath(const std::string &filename)
+{
+   return fmt::format("{}/decaf/{}", platform::getConfigDirectory(), filename.c_str());
+}
+
+bool
+createConfigDirectory()
+{
+   return platform::createParentDirectories(makeConfigPath("."));
+}
+
 void
 initialiseLogging(std::vector<spdlog::sink_ptr> &sinks,
                   spdlog::level::level_enum level)


### PR DESCRIPTION
Mainly so the system doesn't get littered with config.json and imgui.ini files in every directory you run the emulator from. I'll need someone else to write and test the code for Windows since I don't have a Windows build environment.