### PR TITLE
jit: Adjust call sequences to work on Linux.

### DIFF
--- a/src/libcpu/src/jit/jit.cpp
+++ b/src/libcpu/src/jit/jit.cpp
@@ -69,9 +69,14 @@ initStubs()
    a.push(asmjit::x86::r14);
    a.push(asmjit::x86::r15);
    a.sub(asmjit::x86::rsp, 0x38);
-   a.mov(a.stateReg, asmjit::x86::rcx);
    a.mov(a.membaseReg, static_cast<uint64_t>(mem::base()));
+#ifdef PLATFORM_WINDOWS
+   a.mov(a.stateReg, asmjit::x86::rcx);
    a.jmp(asmjit::x86::rdx);
+#else
+   a.mov(a.stateReg, asmjit::x86::rdi);
+   a.jmp(asmjit::x86::rsi);
+#endif
 
    // This is the piece of code executed when we are finished
    //  executing the block of code started above.

--- a/src/libcpu/src/jit/jit_fallback.cpp
+++ b/src/libcpu/src/jit/jit_fallback.cpp
@@ -33,8 +33,13 @@ bool jit_fallback(PPCEmuAssembler& a, espresso::Instruction instr)
       a.lock().inc(asmjit::X86Mem(asmjit::x86::rax, 0));
    }
 
+#ifdef PLATFORM_WINDOWS
    a.mov(asmjit::x86::rcx, a.stateReg);
    a.mov(asmjit::x86::rdx, (uint32_t)instr);
+#else
+   a.mov(asmjit::x86::rdi, a.stateReg);
+   a.mov(asmjit::x86::rsi, (uint32_t)instr);
+#endif
    a.call(asmjit::Ptr(fptr));
    return true;
 }

--- a/src/libcpu/src/jit/jit_internal.h
+++ b/src/libcpu/src/jit/jit_internal.h
@@ -21,9 +21,9 @@ RAX    . Scratch
 RCX    . Scratch
 RDX    . Scratch
 RDI    . Scratch
-RSI    . mem::base()
+RSI    . Scratch
 RBX    . Core*
-RBP    . Scratch
+RBP    . mem::base()
 RSP    . Emu Stack Pointer.
 R8-R15 . Scratch
 */
@@ -84,7 +84,7 @@ public:
       setErrorHandler(&errHandler);
 
       stateReg = zbx;
-      membaseReg = zsi;
+      membaseReg = zbp;
 
 #define PPCMemRef(s, mm) s = asmjit::X86Mem(stateReg, (int32_t)offsetof2(Core, mm), sizeof(Core::mm))
 
@@ -127,7 +127,7 @@ public:
       mGpRegVals[1] = asmjit::x86::rcx;
       mGpRegVals[2] = asmjit::x86::rdx;
       mGpRegVals[3] = asmjit::x86::rdi;
-      mGpRegVals[4] = asmjit::x86::rbp;
+      mGpRegVals[4] = asmjit::x86::rsi;
       mGpRegVals[5] = asmjit::x86::r8;
       mGpRegVals[6] = asmjit::x86::r9;
       mGpRegVals[7] = asmjit::x86::r10;

--- a/src/libcpu/src/jit/jit_system.cpp
+++ b/src/libcpu/src/jit/jit_system.cpp
@@ -166,8 +166,13 @@ kc(PPCEmuAssembler& a, Instruction instr)
    a.mov(a.niaMem, a.genCia + 4);
 
    // Call the KC
+#ifdef PLATFORM_WINDOWS
    a.mov(asmjit::x86::rcx, asmjit::Ptr(kc->func));
    a.mov(asmjit::x86::rdx, asmjit::Ptr(kc->user_data));
+#else
+   a.mov(asmjit::x86::rdi, asmjit::Ptr(kc->func));
+   a.mov(asmjit::x86::rsi, asmjit::Ptr(kc->user_data));
+#endif
    a.call(asmjit::Ptr(&kc_stub));
    a.mov(a.stateReg, asmjit::x86::rax);
 


### PR DESCRIPTION
Linux uses the System V ABI, which differs from Windows in a few respects:
 - Register arguments are passed in RDI, RSI, RDX, RCX, R8, R9
 - RDI and RSI are volatile (so I moved mem::base() from RSI to RBP)
 - All XMM registers are volatile
 - The 128-byte region immediately below SP (red zone) is volatile
 - No argument shadow space is required for subroutine calls