### PR TITLE
Make the emulated system region configurable.

### DIFF
--- a/src/decaf-cli/main.cpp
+++ b/src/decaf-cli/main.cpp
@@ -1,6 +1,8 @@
+#include "common/decaf_assert.h"
 #include "config.h"
 #include "decafcli.h"
 #include "libdecaf/decaf.h"
+#include "libdecaf/src/modules/coreinit/coreinit_enum.h"
 #include <pugixml.hpp>
 #include <excmd.h>
 #include <iostream>
@@ -59,6 +61,12 @@ getCommandLineParser()
       .add_option("sys-path",
                   description { "Where to locate any external system files." },
                   value<std::string> {})
+      .add_option("region",
+                  description { "Set the system region." },
+                  default_value<std::string> { "US" },
+                  allowed<std::string> { {
+                        "EUR", "JAP", "US"
+                  } })
       .add_option("timeout_ms",
                   description { "How long to execute the game for before quitting." },
                   value<uint32_t> {});

--- a/src/decaf-sdl/main.cpp
+++ b/src/decaf-sdl/main.cpp
@@ -1,7 +1,9 @@
 #include "clilog.h"
+#include "common/decaf_assert.h"
 #include "config.h"
 #include "decafsdl.h"
 #include "libdecaf/decaf.h"
+#include "libdecaf/src/modules/coreinit/coreinit_enum.h"
 #include <pugixml.hpp>
 #include <excmd.h>
 #include <iostream>
@@ -59,7 +61,13 @@ getCommandLineParser()
                   value<std::string> {})
       .add_option("sys-path",
                   description { "Where to locate any external system files." },
-                  value<std::string> {});
+                  value<std::string> {})
+      .add_option("region",
+                  description { "Set the system region." },
+                  default_value<std::string> { "US" },
+                  allowed<std::string> { {
+                        "EUR", "JAP", "US"
+                  } });
 
    parser.add_command("play")
       .add_option_group(jit_options)

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -61,6 +61,9 @@ namespace system
 //! Path to system files
 extern std::string system_path;
 
+//! Emulated system region
+extern int region;
+
 } // namespace system
 
 } // namespace config

--- a/src/libdecaf/src/decaf_config.cpp
+++ b/src/libdecaf/src/decaf_config.cpp
@@ -1,4 +1,5 @@
 #include "decaf_config.h"
+#include "modules/coreinit/coreinit_enum.h"
 
 namespace decaf
 {
@@ -55,6 +56,7 @@ namespace system
 {
 
 std::string system_path = "/undefined_system_path";
+int region = static_cast<int>(coreinit::SCIRegion::US);
 
 } // namespace system
 

--- a/src/libdecaf/src/modules/coreinit/coreinit_enum.h
+++ b/src/libdecaf/src/modules/coreinit/coreinit_enum.h
@@ -284,6 +284,7 @@ ENUM_BEG(SCILanguage, uint32_t)
 ENUM_END(SCILanguage)
 
 ENUM_BEG(SCIRegion, uint8_t)
+   ENUM_VALUE(JAP,                  0x01)
    ENUM_VALUE(US,                   0x02)
    ENUM_VALUE(EUR,                  0x04)
 ENUM_END(SCIRegion)

--- a/src/libdecaf/src/modules/coreinit/coreinit_mcp.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_mcp.cpp
@@ -1,6 +1,7 @@
 #include "coreinit.h"
 #include "coreinit_mcp.h"
 #include "common/decaf_assert.h"
+#include "decaf_config.h"
 
 namespace coreinit
 {
@@ -28,8 +29,8 @@ MCP_GetSysProdSettings(IOHandle handle, MCPSysProdSettings *settings)
    }
 
    memset(settings, 0, sizeof(MCPSysProdSettings));
-   settings->gameRegion = SCIRegion::US;
-   settings->platformRegion = SCIRegion::US;
+   settings->gameRegion = static_cast<SCIRegion>(decaf::config::system::region);
+   settings->platformRegion = static_cast<SCIRegion>(decaf::config::system::region);
    return IOError::OK;
 }
 


### PR DESCRIPTION
Not sure how you feel about #including coreinit_enum.h at higher levels just to get the region enums. Another possibility would be to store it as a string and do the conversion within coreinit::MCP_GetSysProdSettings(), which is a bit slower but I can't imagine that function is a hotspot.