### PR TITLE
coreinit: Update thread switch time even when switching to no thread.

### DIFF
--- a/src/libdecaf/src/modules/coreinit/coreinit_scheduler.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_scheduler.cpp
@@ -314,12 +314,12 @@ void checkRunningThreadNoLock(bool yielding)
    }
 
    // Update thread core time tracking stuff
+   auto now = std::chrono::high_resolution_clock::now();
    if (thread) {
-      auto now = std::chrono::high_resolution_clock::now();
       auto diff = now - sLastSwitchTime[coreId];
       thread->coreTimeConsumedNs += diff.count();
-      sLastSwitchTime[coreId] = now;
    }
+   sLastSwitchTime[coreId] = now;
    if (next) {
       next->wakeCount++;
    }


### PR DESCRIPTION
Fixes non-running threads being credited with idle time when a core goes idle.