### PR TITLE
cmake: Fix build failure with parallel build in fresh directory.

### DIFF
--- a/src/libdecaf/CMakeLists.txt
+++ b/src/libdecaf/CMakeLists.txt
@@ -5,3 +5,6 @@ file(GLOB_RECURSE SOURCE_FILES *.cpp)
 file(GLOB_RECURSE HEADER_FILES *.h)
 
 add_library(libdecaf STATIC ${SOURCE_FILES} ${HEADER_FILES})
+
+# glbinding has to be built first so it can generate glbinding_api.h
+add_dependencies(libdecaf glbinding)


### PR DESCRIPTION
When running a CMake build with sufficient parallelism (e.g. make -j9) in a freshly created build directory, the build will fail because of a missing header:
```
In file included from [...]/decaf-emu/src/libdecaf/src/gpu/opengl/opengl_driver.h:10:
[...]/decaf-emu/libraries/glbinding/source/glbinding/include/glbinding/gl/types.h:4:10: fatal error: 
      'glbinding/glbinding_api.h' file not found
#include <glbinding/glbinding_api.h>
```
glbinding_api.h is a generated header, so libdecaf needs an explicit dependency to ensure that the header is available. (It would be nice if we could have a dependency just on the header and not on the entire library, because some of the glbinding sources take forever to compile, but I don't know CMake well enough to say whether that's possible.)