### PR TITLE
kernel: Skip normal interrupt processing for breakpoints.

### DIFF
--- a/src/libdecaf/src/kernel/kernel.cpp
+++ b/src/libdecaf/src/kernel/kernel.cpp
@@ -207,7 +207,8 @@ cpuInterruptHandler(uint32_t interrupt_flags)
       coreinit::internal::pauseCoreTime(false);
    }
 
-   if (!(interrupt_flags & ~cpu::NONMASKABLE_INTERRUPTS)) {
+   auto unsafeInterrupts = cpu::NONMASKABLE_INTERRUPTS | cpu::DBGBREAK_INTERRUPT;
+   if (!(interrupt_flags & ~unsafeInterrupts)) {
       // Due to the fact that non-maskable interrupts are not able to be disabled
       // it is possible the application has the scheduler lock or something, so we
       // need to stop processing here or else bad things could happen.


### PR DESCRIPTION
Breakpoints are not masked by OSDisableInterrupts(), so if a core was stopped with interrupts disabled, the cpu::this_core::interruptMask() == cpu::INTERRUPT_MASK assertion in coreinit::internal::checkRunningThreadNoLock() would fail when the core resumed.

For me, this triggered sporadically when trying to step in the debugger after hitting a breakpoint.