### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/common/src/assert.cpp
+++ b/src/common/src/assert.cpp
@@ -8,6 +8,8 @@
 #include <cassert>
 #include <codecvt>
 #include <Windows.h>
+
+#pragma comment(lib, "dbghelp.lib")
 #endif
 
 void


### PR DESCRIPTION
This was caused by 73b6a6e68d776f04274360e9a744d4784beff3af

Not sure if this is how you want to link libraries, I'm not too experienced with C++ or Decaf's code. :) If there's a better way, I can change it.