### PR TITLE
Mask cb_shader_mask to select only the bits for the current export

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -1127,7 +1127,7 @@ bool GLDriver::compilePixelShader(PixelShader &pixel, VertexShader &vertex, uint
       switch (exp.type) {
       case latte::SQ_EXPORT_PIXEL:
       {
-         auto mask = cb_shader_mask.value >> (4 * exp.id);
+         auto mask = (cb_shader_mask.value >> (4 * exp.id)) & 0x0F;
 
          if (!mask) {
             gLog->warn("Export is masked by cb_shader_mask");


### PR DESCRIPTION
Fixes a problem for a shader in Xenoblade. It exports to export 0, but only export 2 is enabled. Because the higher order bits of cb_shader_mask are not masked out, the fact that a higher numbered export is enabled causes the check if the current export is fully masked to fail.

Idk if this is being caused by another issue somewhere (several asserts have to be ignored to get Xenoblade to the point when this shader is compiled), but to me this seems like a bug regardless.