### PR TITLE
opengl: Support 3D textures.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_texture.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_texture.cpp
@@ -401,6 +401,25 @@ bool GLDriver::checkActiveTextures()
                                           untiledImage.data());
                }
                break;
+            case latte::SQ_TEX_DIM_3D:
+               if (compressed) {
+                  gl::glCompressedTextureSubImage3D(buffer->object,
+                                                    0, /* level */
+                                                    0, 0, 0, /* xoffset, yoffset, zoffset */
+                                                    width, height, depth,
+                                                    textureDataType,
+                                                    gsl::narrow_cast<gl::GLsizei>(size),
+                                                    untiledImage.data());
+               } else {
+                  gl::glTextureSubImage3D(buffer->object,
+                                          0, /* level */
+                                          0, 0, 0, /* xoffset, yoffset, zoffset */
+                                          width, height, depth,
+                                          textureFormat,
+                                          textureDataType,
+                                          untiledImage.data());
+               }
+               break;
             case latte::SQ_TEX_DIM_CUBEMAP:
                decaf_check(surface.depth == 6);
             case latte::SQ_TEX_DIM_2D_ARRAY:


### PR DESCRIPTION
Xenoblade uses some of these. The emulator doesn't yet actually render any 3D scenes so I can't verify that this is correct, but hopefully it's straightforward?