### PR TITLE
jit: Fix an array overrun

### DIFF
--- a/src/libcpu/src/jit/jit.cpp
+++ b/src/libcpu/src/jit/jit.cpp
@@ -33,7 +33,7 @@ static FastRegionMap<JitCode>
 sJitBlocks;
 
 static uint8_t
-sBaseRelocCode[16];
+sBaseRelocCode[32];
 
 JitCall
 gCallFn;


### PR DESCRIPTION
Based off initialization code, this is actually supposed to be 32 bytes in size.