### PR TITLE
opengl: Cache current graphics state to avoid redundant GL calls.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
@@ -11,7 +11,19 @@ namespace opengl
 bool GLDriver::checkActiveDepthBuffer()
 {
    auto db_depth_base = getRegister<latte::DB_DEPTH_BASE>(latte::Register::DB_DEPTH_BASE);
+   auto db_depth_size = getRegister<latte::DB_DEPTH_SIZE>(latte::Register::DB_DEPTH_SIZE);
+   auto db_depth_info = getRegister<latte::DB_DEPTH_INFO>(latte::Register::DB_DEPTH_INFO);
    auto &active = mActiveDepthBuffer;
+
+   if (db_depth_base.value == mDepthBufferCache.base
+    && db_depth_size.value == mDepthBufferCache.size
+    && db_depth_info.value == mDepthBufferCache.info) {
+      return true;
+   }
+
+   mDepthBufferCache.base = db_depth_base.value;
+   mDepthBufferCache.size = db_depth_size.value;
+   mDepthBufferCache.info = db_depth_info.value;
 
    if (!db_depth_base.BASE_256B) {
       if (active) {
@@ -25,8 +37,6 @@ bool GLDriver::checkActiveDepthBuffer()
    }
 
    // Bind depth buffer
-   auto db_depth_size = getRegister<latte::DB_DEPTH_SIZE>(latte::Register::DB_DEPTH_SIZE);
-   auto db_depth_info = getRegister<latte::DB_DEPTH_INFO>(latte::Register::DB_DEPTH_INFO);
    active = getDepthBuffer(db_depth_base, db_depth_size, db_depth_info);
    auto dbFormat = db_depth_info.FORMAT();
    if (dbFormat == latte::DEPTH_8_24

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -29,7 +29,6 @@ void GLDriver::initGL()
    mActiveShader = nullptr;
    mActiveDepthBuffer = nullptr;
    memset(&mActiveColorBuffers[0], 0, sizeof(SurfaceBuffer *) * mActiveColorBuffers.size());
-   std::memset(&mPendingEOP, 0, sizeof(pm4::EventWriteEOP));
 
    // Create our blit framebuffer
    gl::glCreateFramebuffers(2, mBlitFrameBuffers);

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -149,6 +149,41 @@ struct UniformBuffer
    gl::GLuint object = 0;
 };
 
+struct ColorBufferCache
+{
+   uint32_t base = 0;
+   uint32_t size = 0;
+   uint32_t info = 0;
+   uint32_t mask = 0;
+};
+
+struct DepthBufferCache
+{
+   uint32_t base = 0;
+   uint32_t size = 0;
+   uint32_t info = 0;
+};
+
+struct TextureCache
+{
+   uint32_t baseAddress = 0;
+   uint32_t word0 = 0;
+   uint32_t word1 = 0;
+   uint32_t word2 = 0;
+   uint32_t word3 = 0;
+   uint32_t word4 = 0;
+   uint32_t word5 = 0;
+   uint32_t word6 = 0;
+};
+
+struct SamplerCache
+{
+   uint32_t word0 = 0;
+   uint32_t word1 = 0;
+   uint32_t word2 = 0;
+   bool depthCompare = false;  // TODO: might be unnecessary; see TODO note in checkActiveSamplers()
+};
+
 using GLContext = uint64_t;
 
 class GLDriver : public decaf::OpenGLDriver
@@ -289,6 +324,11 @@ private:
    latte::ContextState *mContextState = nullptr;
 
    pm4::EventWriteEOP mPendingEOP;
+
+   std::array<ColorBufferCache, latte::MaxRenderTargets> mColorBufferCache;
+   DepthBufferCache mDepthBufferCache;
+   std::array<TextureCache, latte::MaxTextures> mPixelTextureCache;
+   std::array<SamplerCache, latte::MaxSamplers> mPixelSamplerCache;
 
    using duration_system_clock = std::chrono::duration<double, std::chrono::system_clock::period>;
    using duration_ms = std::chrono::duration<double, std::chrono::milliseconds::period>;


### PR DESCRIPTION
This roughly doubles frame rate and cuts the number of calls per frame by a factor of 15 on the Xenoblade title and options screens.