### PR TITLE
opengl: Avoid redundant GL calls from register setting.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -26,6 +26,9 @@ void GLDriver::initGL()
 {
    // Clear active state
    mRegisters.fill(0);
+   for (auto i = 0u; i < mRegisters.size(); ++i) {
+      applyRegister(static_cast<latte::Register>(i*4));
+   }
    mActiveShader = nullptr;
    mActiveDepthBuffer = nullptr;
    memset(&mActiveColorBuffers[0], 0, sizeof(SurfaceBuffer *) * mActiveColorBuffers.size());

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -288,6 +288,7 @@ private:
    void copyFeedbackBuffer(unsigned index);
 
    void setRegister(latte::Register reg, uint32_t value);
+   void applyRegister(latte::Register reg);
 
    bool parseFetchShader(FetchShader &shader, void *buffer, size_t size);
    bool compileVertexShader(VertexShader &vertex, FetchShader &fetch, uint8_t *buffer, size_t size);


### PR DESCRIPTION
This doesn't have nearly as big an impact as the last change, but it does reduce the call-per-frame count by about 25%.