### PR TITLE
opengl: Fix failure to reuse color buffers as textures.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_surface.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_surface.cpp
@@ -1,3 +1,4 @@
+#include "common/align.h"
 #include "common/decaf_assert.h"
 #include "gpu/latte_enum_sq.h"
 #include "modules/gx2/gx2_addrlib.h"
@@ -299,7 +300,10 @@ GLDriver::getSurfaceBuffer(ppcaddr_t baseAddress,
    decaf_check(height <= 8192);
 
    auto surfaceKey = static_cast<uint64_t>(baseAddress) << 32;
-   surfaceKey ^= width ^ height ^ depth ^ dim;
+   // Note: align_up on width and height is needed to ensure that strangely
+   //  sized framebuffers can be properly reused as textures (for example,
+   //  a 384x320 framebuffer getting drawn as a 384x310 texture)
+   surfaceKey ^= align_up(width, 16) ^ align_up(height, 16) ^ depth ^ dim;
    surfaceKey ^= format ^ numFormat ^ formatComp ^ degamma;
 
    auto bufferIter = mSurfaces.find(surfaceKey);


### PR DESCRIPTION
Fixes Xenoblade 3D rendering not appearing at all. The title screen now looks more or less correct; the character creation screen goes crazy, but at least it shows something.

And yes, Xenoblade renders its world in 768x620. Why 620, I have no clue.