### PR TITLE
opengl: Take the absolute value of LOG_* arguments.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/glsl2_alu_op2.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_alu_op2.cpp
@@ -346,7 +346,16 @@ LSHR(State &state, const ControlFlowInst &cf, const AluInst &alu)
 static void
 LOG(State &state, const ControlFlowInst &cf, const AluInst &alu)
 {
-   unaryFunction(state, cf, alu, "log2");
+   insertLineStart(state);
+   insertDestBegin(state, cf, alu, state.unit);
+
+   state.out << "log2(abs(";
+   insertSource0(state, state.out, cf, alu);
+   state.out << "))";
+
+   insertDestEnd(state, cf, alu);
+   state.out << ';';
+   insertLineEnd(state);
 }
 
 static void


### PR DESCRIPTION
Xenoblade generates a texture with a pixel shader that uses LOG_CLAMPED instructions; without the abs(), the alpha channel ends up as all NaNs.

The R600 docs suggest that LOG_CLAMPED and LOG_IEEE behave the same way, which makes no sense to me but I've applied abs() to both instructions on that basis.