### PR TITLE
Revert 92e56de and 273871e.

### DIFF
--- a/src/libdecaf/decaf_graphics.h
+++ b/src/libdecaf/decaf_graphics.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "common/types.h"
 #include <functional>
 
 namespace decaf
@@ -15,8 +14,6 @@ public:
    virtual void run() = 0;
    virtual void stop() = 0;
    virtual float getAverageFPS() = 0;
-
-   virtual void invalidateMemory(uint32_t mode, ppcaddr_t memStart, ppcaddr_t memEnd) = 0;
 };
 
 class OpenGLDriver : public GraphicsDriver

--- a/src/libdecaf/decaf_nullgraphicsdriver.cpp
+++ b/src/libdecaf/decaf_nullgraphicsdriver.cpp
@@ -40,10 +40,6 @@ NullGraphicsDriver::getAverageFPS()
    return 0.0f;
 }
 
-void NullGraphicsDriver::invalidateMemory(uint32_t mode, ppcaddr_t memStart, ppcaddr_t memEnd)
-{
-}
-
 OpenGLDriver *
 createGLDriver()
 {

--- a/src/libdecaf/decaf_nullgraphicsdriver.h
+++ b/src/libdecaf/decaf_nullgraphicsdriver.h
@@ -13,8 +13,6 @@ public:
    virtual void stop() override;
    virtual float getAverageFPS() override;
 
-   virtual void invalidateMemory(uint32_t mode, ppcaddr_t memStart, ppcaddr_t memEnd) override;
-
 private:
    bool mRunning = false;
 };

--- a/src/libdecaf/src/gpu/commandqueue.cpp
+++ b/src/libdecaf/src/gpu/commandqueue.cpp
@@ -57,13 +57,25 @@ static CommandQueue
 gQueue;
 
 void
-queueUserBuffer(const void *buffer, uint32_t bytes)
+queueSysBuffer(void *buffer, uint32_t dwords)
+{
+   //TODO: Please no allocate
+   auto buf = new pm4::Buffer{};
+   buf->curSize = dwords;
+   buf->maxSize = dwords;
+   buf->buffer = reinterpret_cast<uint32_t *>(buffer);
+   buf->sysBuffer = true;
+   gQueue.appendBuffer(buf);
+}
+
+void
+queueUserBuffer(void *buffer, uint32_t bytes)
 {
    // TODO: Please no allocate
    auto buf = new pm4::Buffer {};
    buf->curSize = bytes / 4;
    buf->maxSize = bytes / 4;
-   buf->buffer = reinterpret_cast<uint32_t *>(const_cast<void*>(buffer));
+   buf->buffer = reinterpret_cast<uint32_t *>(buffer);
    buf->userBuffer = true;
    queueCommandBuffer(buf);
 }
@@ -94,6 +106,12 @@ tryUnqueueCommandBuffer()
 void
 retireCommandBuffer(pm4::Buffer *buf)
 {
+   if (buf->sysBuffer) {
+      delete[] buf->buffer;
+      delete buf;
+      return;
+   }
+
    gx2::internal::setRetiredTimestamp(buf->submitTime);
 
    if (buf->userBuffer) {

--- a/src/libdecaf/src/gpu/commandqueue.h
+++ b/src/libdecaf/src/gpu/commandqueue.h
@@ -10,7 +10,10 @@ namespace gpu
 {
 
 void
-queueUserBuffer(const void *buf, uint32_t bytes);
+queueSysBuffer(void *buf, uint32_t dwords);
+
+void
+queueUserBuffer(void *buf, uint32_t bytes);
 
 void
 queueCommandBuffer(pm4::Buffer *buf);

--- a/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
@@ -30,20 +30,8 @@ GLDriver::runCommandBuffer(uint32_t *buffer, uint32_t buffer_size)
       auto header = *reinterpret_cast<pm4::Header *>(&buffer[pos]);
       auto size = 0u;
 
-      executeTasks();
-
       if (buffer[pos] == 0) {
          break;
-      }
-
-      if (mMutexWaiters.load() > 0) {
-         mMutex.unlock();
-
-         while (mMutexWaiters.load() > 0) {
-            std::this_thread::sleep_for(std::chrono::microseconds(1));
-         }
-
-         mMutex.lock();
       }
 
       switch (header.type()) {
@@ -123,6 +111,9 @@ GLDriver::handlePacketType3(pm4::type3::Header header, const gsl::span<uint32_t>
       break;
    case pm4::type3::DECAF_SET_BUFFER:
       decafSetBuffer(pm4::read<pm4::DecafSetBuffer>(reader));
+      break;
+   case pm4::type3::DECAF_INVALIDATE:
+      decafInvalidate(pm4::read<pm4::DecafInvalidate>(reader));
       break;
    case pm4::type3::DECAF_DEBUGMARKER:
       decafDebugMarker(pm4::read<pm4::DecafDebugMarker>(reader));

--- a/src/libdecaf/src/gpu/pm4.h
+++ b/src/libdecaf/src/gpu/pm4.h
@@ -134,6 +134,23 @@ struct DecafSetBuffer
    }
 };
 
+struct DecafInvalidate
+{
+   static const auto Opcode = type3::DECAF_INVALIDATE;
+
+   uint32_t mode;
+   uint32_t memStart;
+   uint32_t memEnd;
+
+   template<typename Serialiser>
+   void serialise(Serialiser &se)
+   {
+      se(mode);
+      se(memStart);
+      se(memEnd);
+   }
+};
+
 struct DecafDebugMarker
 {
    static const auto Opcode = type3::DECAF_DEBUGMARKER;

--- a/src/libdecaf/src/gpu/pm4_buffer.h
+++ b/src/libdecaf/src/gpu/pm4_buffer.h
@@ -8,6 +8,7 @@ namespace pm4
 
 struct Buffer
 {
+   bool sysBuffer = false;
    bool userBuffer = false;
    bool displayList = false;
    coreinit::OSTime submitTime = 0;

--- a/src/libdecaf/src/gpu/pm4_format.h
+++ b/src/libdecaf/src/gpu/pm4_format.h
@@ -17,7 +17,7 @@ enum IT_OPCODE : uint32_t
    DECAF_CLEAR_DEPTH_STENCIL  = 0x04,
    DECAF_SET_CONTEXT_STATE    = 0x05,
    DECAF_SET_BUFFER           = 0x06,
-   // 0x07 is currently unused
+   DECAF_INVALIDATE           = 0x07,
    DECAF_DEBUGMARKER          = 0x08,
    DECAF_OSSCREEN_FLIP        = 0x09,
 

--- a/src/libdecaf/src/modules/gx2/gx2_mem.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_mem.cpp
@@ -1,4 +1,3 @@
-#include "decaf_graphics.h"
 #include "gx2_mem.h"
 #include "gx2_state.h"
 #include "gpu/commandqueue.h"
@@ -19,7 +18,19 @@ GX2Invalidate(GX2InvalidateMode mode,
    auto memStart = mem::untranslate(buffer);
    auto memEnd = memStart + size;
 
-   decaf::getGraphicsDriver()->invalidateMemory(mode, memStart, memEnd);
+   // Custom build the packet so we can send it through
+   //  the system packet path rather than the normal one.
+   auto packet = new be_val<uint32_t>[4];
+   packet[0] = pm4::type3::Header::get(0)
+      .type(pm4::Header::Type3)
+      .opcode(pm4::DecafInvalidate::Opcode)
+      .size(4 - 2)
+      .value;
+   packet[1] = mode;
+   packet[2] = memStart;
+   packet[3] = memEnd;
+
+   gpu::queueSysBuffer(packet, 4);
 }
 
 } // namespace gx2


### PR DESCRIPTION
gx2.rpl uses PM4 commands for invalidation, so we should do so as well.