### PR TITLE
opengl: Fix overly aggressive texture upload avoidance.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -175,14 +175,8 @@ struct DepthBufferCache
 
 struct TextureCache
 {
-   uint32_t baseAddress = 0;
-   uint32_t word0 = 0;
-   uint32_t word1 = 0;
-   uint32_t word2 = 0;
-   uint32_t word3 = 0;
+   uint32_t surfaceObject = 0;
    uint32_t word4 = 0;
-   uint32_t word5 = 0;
-   uint32_t word6 = 0;
 };
 
 struct SamplerCache


### PR DESCRIPTION
I got slightly overenthusiastic with the caching; we can't skip uploading a dirty texture just because the registers haven't changed. (But we can still skip the GL state updates.)