### PR TITLE
opengl: Fix failure to upload new data when expanding a data buffer.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -621,8 +621,12 @@ GLDriver::configureDataBuffer(DataBuffer *buffer,
    //  uniform buffers.  This has to be done after mapping, since if we're
    //  using maps, we can't update the buffer via glBufferSubData (because
    //  we didn't specify GL_DYNAMIC_STORAGE_BIT).
-   if (!oldObject && isInput) {
-      uploadDataBuffer(buffer, 0, size);
+   if (isInput) {
+      if (!oldObject) {
+         uploadDataBuffer(buffer, 0, size);
+      } else if (size > oldSize) {
+         uploadDataBuffer(buffer, oldSize, size - oldSize);
+      }
    }
 }
 


### PR DESCRIPTION
Oops.

Also, I noticed Xenoblade reuses the same portion of memory for different sized attribute buffers (as I imagine a lot of games might do), so we could end up with many GL data buffers overlapping the same address. Not sure offhand what the best solution to this is.