### PR TITLE
gx2: Shift depth buffer addresses by 8 in PM4 depth-clear packet.

### DIFF
--- a/src/libdecaf/src/modules/gx2/gx2_clear.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_clear.cpp
@@ -43,9 +43,9 @@ DecafClearDepthStencil(GX2DepthBuffer *depthBuffer,
 
    pm4::write(pm4::DecafClearDepthStencil {
       clearFlags,
-      depthBuffer->surface.image.getAddress(),
+      depthBuffer->surface.image.getAddress() >> 8,
       depthBuffer->regs.db_depth_info,
-      depthBuffer->hiZPtr.getAddress(),
+      depthBuffer->hiZPtr.getAddress() >> 8,
       depthBuffer->regs.db_depth_size,
       depthBuffer->regs.db_depth_view,
    });


### PR DESCRIPTION
Forgot that clear operations use a separate packet.