### PR TITLE
Pass the swap interval from GX2SetSwapInterval to the graphics driver.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -153,6 +153,14 @@ GLDriver::decafSwapBuffers(const pm4::DecafSwapBuffers &data)
 }
 
 void
+GLDriver::decafSetSwapInterval(const pm4::DecafSetSwapInterval &data)
+{
+   decaf_assert(data.interval <= 10, fmt::format("Bizarre swap interval {}", data.interval));
+
+   mSwapInterval = data.interval;
+}
+
+void
 GLDriver::decafSetContextState(const pm4::DecafSetContextState &data)
 {
    mContextState = reinterpret_cast<latte::ContextState *>(data.context.get());

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -229,6 +229,7 @@ private:
    void decafDebugMarker(const pm4::DecafDebugMarker &data);
    void decafOSScreenFlip(const pm4::DecafOSScreenFlip &data);
    void decafCopySurface(const pm4::DecafCopySurface &data);
+   void decafSetSwapInterval(const pm4::DecafSetSwapInterval &data);
    void drawIndexAuto(const pm4::DrawIndexAuto &data);
    void drawIndex2(const pm4::DrawIndex2 &data);
    void drawIndexImmd(const pm4::DrawIndexImmd &data);
@@ -348,6 +349,7 @@ private:
 
    volatile RunState mRunState = RunState::None;
    std::thread mThread;
+   unsigned mSwapInterval = 1;
    SwapFunction mSwapFunc;
 
    std::array<uint32_t, 0x10000> mRegisters;

--- a/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
@@ -121,6 +121,9 @@ GLDriver::handlePacketType3(pm4::type3::Header header, const gsl::span<uint32_t>
    case pm4::type3::DECAF_COPY_SURFACE:
       decafCopySurface(pm4::read<pm4::DecafCopySurface>(reader));
       break;
+   case pm4::type3::DECAF_SET_SWAP_INTERVAL:
+      decafSetSwapInterval(pm4::read<pm4::DecafSetSwapInterval>(reader));
+      break;
    case pm4::type3::DRAW_INDEX_AUTO:
       drawIndexAuto(pm4::read<pm4::DrawIndexAuto>(reader));
       break;

--- a/src/libdecaf/src/gpu/pm4.h
+++ b/src/libdecaf/src/gpu/pm4.h
@@ -23,6 +23,19 @@ struct DecafSwapBuffers
    }
 };
 
+struct DecafSetSwapInterval
+{
+   static const auto Opcode = type3::DECAF_SET_SWAP_INTERVAL;
+
+   uint32_t interval;
+
+   template<typename Serialiser>
+   void serialise(Serialiser &se)
+   {
+      se(interval);
+   }
+};
+
 struct DecafSetContextState
 {
    static const auto Opcode = type3::DECAF_SET_CONTEXT_STATE;

--- a/src/libdecaf/src/gpu/pm4_format.h
+++ b/src/libdecaf/src/gpu/pm4_format.h
@@ -20,6 +20,7 @@ enum IT_OPCODE : uint32_t
    DECAF_COPY_SURFACE         = 0x07,
    DECAF_DEBUGMARKER          = 0x08,
    DECAF_OSSCREEN_FLIP        = 0x09,
+   DECAF_SET_SWAP_INTERVAL    = 0x0A,
 
    NOP                        = 0x10,
    INDIRECT_BUFFER_END        = 0x17,

--- a/src/libdecaf/src/modules/gx2/gx2_swap.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_swap.cpp
@@ -8,7 +8,7 @@ namespace gx2
 {
 
 static uint32_t
-gSwapInterval { 1 };
+sSwapInterval = 1;
 
 void
 GX2CopyColorBufferToScanBuffer(GX2ColorBuffer *buffer, GX2ScanTarget scanTarget)
@@ -63,13 +63,20 @@ GX2GetLastFrameGamma(GX2ScanTarget scanTarget, be_val<float> *gamma)
 uint32_t
 GX2GetSwapInterval()
 {
-   return gSwapInterval;
+   return sSwapInterval;
 }
 
 void
 GX2SetSwapInterval(uint32_t interval)
 {
-   gSwapInterval = interval;
+   if (interval != sSwapInterval) {
+      if (interval == 0) {
+         gLog->warn("Swap interval set to 0!\n");
+      }
+
+      sSwapInterval = interval;
+      pm4::write(pm4::DecafSetSwapInterval { interval });
+   }
 }
 
 } // namespace gx2


### PR DESCRIPTION
GLDriver doesn't actually make use of this yet; I have a separate patch for that, but Brett suggested there were other issues to consider, so I'll file it in a separate PR.

FYI, gx2.rpl implements this by writing the value to what I assume (based on the DCInvalidateRange/DCFlushRange calls that bracket it) is a control block shared with the GPU.