### PR TITLE
opengl: Configure color/depth buffers after textures.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
@@ -11,23 +11,6 @@ namespace opengl
 
 bool GLDriver::checkReadyDraw()
 {
-   if (!checkActiveColorBuffer()) {
-      gLog->warn("Skipping draw with invalid color buffer.");
-      return false;
-   }
-
-   if (!checkActiveDepthBuffer()) {
-      gLog->warn("Skipping draw with invalid depth buffer.");
-      return false;
-   }
-
-   auto fbStatus = gl::glCheckFramebufferStatus(gl::GL_FRAMEBUFFER);
-
-   if (fbStatus != gl::GL_FRAMEBUFFER_COMPLETE) {
-      gLog->warn("Draw attempted with an incomplete framebuffer, status {}.", glbinding::Meta::getString(fbStatus));
-      return false;
-   }
-
    if (!checkActiveShader()) {
       gLog->warn("Skipping draw with invalid shader.");
       return false;
@@ -55,6 +38,22 @@ bool GLDriver::checkReadyDraw()
 
    if (!checkActiveSamplers()) {
       gLog->warn("Skipping draw with invalid samplers.");
+      return false;
+   }
+   if (!checkActiveColorBuffer()) {
+      gLog->warn("Skipping draw with invalid color buffer.");
+      return false;
+   }
+
+   if (!checkActiveDepthBuffer()) {
+      gLog->warn("Skipping draw with invalid depth buffer.");
+      return false;
+   }
+
+   auto fbStatus = gl::glCheckFramebufferStatus(gl::GL_FRAMEBUFFER);
+
+   if (fbStatus != gl::GL_FRAMEBUFFER_COMPLETE) {
+      gLog->warn("Draw attempted with an incomplete framebuffer, status {}.", glbinding::Meta::getString(fbStatus));
       return false;
    }
 


### PR DESCRIPTION
@brett19: This is a side effect of your new logic to manage differing surface sizes at the same address. I've made this change since we clearly need to render into the active texture, but Xenoblade seems to have a lot of draw operations in which the same surface is both texture and render target, and I don't yet know if it's relying on any special behavior for that case.