### PR TITLE
Honor the swap interval set by the game.

### DIFF
--- a/src/decaf-sdl/decafsdl.cpp
+++ b/src/decaf-sdl/decafsdl.cpp
@@ -144,10 +144,19 @@ DecafSDL::run(const std::string &gamePath)
             mGraphicsDriver->run();
          } };
    } else {
-      // Set the swap interval to 0 so that we don't slow
-      //  down the GPU system when presenting...  The game should
-      //  throttle our swapping automatically anyways.
-      SDL_GL_SetSwapInterval(0);
+      // If the host frame rate is reasonably close to 60fps, use host vsync
+      //  when the game requests it; otherwise disable host vsync (GLDriver
+      //  will take care of timing in any case)
+      SDL_DisplayMode mode;
+      if (SDL_GetWindowDisplayMode(mWindow, &mode) == 0
+       && mode.refresh_rate >= 59
+       && mode.refresh_rate <= 61) {
+         mGraphicsDriver->setSwapIntervalHandler([](int interval) {
+            SDL_GL_SetSwapInterval(interval);
+         });
+      } else {
+         SDL_GL_SetSwapInterval(0);
+      }
 
       // Switch to the thread context, we automatically switch
       //  back when presenting a frame.

--- a/src/libdecaf/decaf_graphics.h
+++ b/src/libdecaf/decaf_graphics.h
@@ -21,12 +21,14 @@ class OpenGLDriver : public GraphicsDriver
 {
 public:
    using SwapFunction = std::function<void(unsigned int, unsigned int)>;
+   using SetSwapIntervalFunction = std::function<void(int)>;
 
    virtual ~OpenGLDriver()
    {
    }
 
    virtual void getSwapBuffers(unsigned int *tv, unsigned int *drc) = 0;
+   virtual void setSwapIntervalHandler(const SetSwapIntervalFunction &handler) = 0;
    virtual void syncPoll(const SwapFunction &swapFunc) = 0;
 };
 

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -153,6 +153,14 @@ GLDriver::decafSwapBuffers(const pm4::DecafSwapBuffers &data)
 }
 
 void
+GLDriver::decafSetSwapInterval(const pm4::DecafSetSwapInterval &data)
+{
+   decaf_assert(data.interval <= 10, fmt::format("Bizarre swap interval {}", data.interval));
+
+   mSwapInterval = data.interval;
+}
+
+void
 GLDriver::decafSetContextState(const pm4::DecafSetContextState &data)
 {
    mContextState = reinterpret_cast<latte::ContextState *>(data.context.get());

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -229,6 +229,7 @@ private:
    void decafDebugMarker(const pm4::DecafDebugMarker &data);
    void decafOSScreenFlip(const pm4::DecafOSScreenFlip &data);
    void decafCopySurface(const pm4::DecafCopySurface &data);
+   void decafSetSwapInterval(const pm4::DecafSetSwapInterval &data);
    void drawIndexAuto(const pm4::DrawIndexAuto &data);
    void drawIndex2(const pm4::DrawIndex2 &data);
    void drawIndexImmd(const pm4::DrawIndexImmd &data);
@@ -348,6 +349,7 @@ private:
 
    volatile RunState mRunState = RunState::None;
    std::thread mThread;
+   unsigned mSwapInterval = 1;
    SwapFunction mSwapFunc;
 
    std::array<uint32_t, 0x10000> mRegisters;

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -209,7 +209,9 @@ public:
    virtual void run() override;
    virtual void stop() override;
    virtual float getAverageFPS() override;
+
    virtual void getSwapBuffers(unsigned int *tv, unsigned int *drc) override;
+   virtual void setSwapIntervalHandler(const SetSwapIntervalFunction &handler) override;
    virtual void syncPoll(const SwapFunction &swapFunc) override;
 
 private:
@@ -349,6 +351,7 @@ private:
 
    volatile RunState mRunState = RunState::None;
    std::thread mThread;
+   SetSwapIntervalFunction mSetSwapIntervalFunc;
    unsigned mSwapInterval = 1;
    SwapFunction mSwapFunc;
 
@@ -397,7 +400,8 @@ private:
 
    using duration_system_clock = std::chrono::duration<double, std::chrono::system_clock::period>;
    using duration_ms = std::chrono::duration<double, std::chrono::milliseconds::period>;
-   std::chrono::time_point<std::chrono::system_clock> mLastSwap;
+   using time_point_system_clock = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<double>>;
+   time_point_system_clock mLastSwap;
    duration_system_clock mAverageFrameTime;
 
 #ifdef PLATFORM_WINDOWS

--- a/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
@@ -121,6 +121,9 @@ GLDriver::handlePacketType3(pm4::type3::Header header, const gsl::span<uint32_t>
    case pm4::type3::DECAF_COPY_SURFACE:
       decafCopySurface(pm4::read<pm4::DecafCopySurface>(reader));
       break;
+   case pm4::type3::DECAF_SET_SWAP_INTERVAL:
+      decafSetSwapInterval(pm4::read<pm4::DecafSetSwapInterval>(reader));
+      break;
    case pm4::type3::DRAW_INDEX_AUTO:
       drawIndexAuto(pm4::read<pm4::DrawIndexAuto>(reader));
       break;

--- a/src/libdecaf/src/gpu/pm4.h
+++ b/src/libdecaf/src/gpu/pm4.h
@@ -23,6 +23,19 @@ struct DecafSwapBuffers
    }
 };
 
+struct DecafSetSwapInterval
+{
+   static const auto Opcode = type3::DECAF_SET_SWAP_INTERVAL;
+
+   uint32_t interval;
+
+   template<typename Serialiser>
+   void serialise(Serialiser &se)
+   {
+      se(interval);
+   }
+};
+
 struct DecafSetContextState
 {
    static const auto Opcode = type3::DECAF_SET_CONTEXT_STATE;

--- a/src/libdecaf/src/gpu/pm4_format.h
+++ b/src/libdecaf/src/gpu/pm4_format.h
@@ -20,6 +20,7 @@ enum IT_OPCODE : uint32_t
    DECAF_COPY_SURFACE         = 0x07,
    DECAF_DEBUGMARKER          = 0x08,
    DECAF_OSSCREEN_FLIP        = 0x09,
+   DECAF_SET_SWAP_INTERVAL    = 0x0A,
 
    NOP                        = 0x10,
    INDIRECT_BUFFER_END        = 0x17,

--- a/src/libdecaf/src/modules/gx2/gx2_swap.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_swap.cpp
@@ -8,7 +8,7 @@ namespace gx2
 {
 
 static uint32_t
-gSwapInterval { 1 };
+sSwapInterval = 1;
 
 void
 GX2CopyColorBufferToScanBuffer(GX2ColorBuffer *buffer, GX2ScanTarget scanTarget)
@@ -63,13 +63,20 @@ GX2GetLastFrameGamma(GX2ScanTarget scanTarget, be_val<float> *gamma)
 uint32_t
 GX2GetSwapInterval()
 {
-   return gSwapInterval;
+   return sSwapInterval;
 }
 
 void
 GX2SetSwapInterval(uint32_t interval)
 {
-   gSwapInterval = interval;
+   if (interval != sSwapInterval) {
+      if (interval == 0) {
+         gLog->warn("Swap interval set to 0!\n");
+      }
+
+      sSwapInterval = interval;
+      pm4::write(pm4::DecafSetSwapInterval { interval });
+   }
 }
 
 } // namespace gx2


### PR DESCRIPTION
The delay in decafSwapBuffers() is intentionally unconditional on whether the host GPU has v-sync enabled. If the host frame rate is less than 59.94 fps, it'll just sync to that rate; if it's greater than 59.94, there will be an occasional 1-frame delay, but you'd still get an effective 1-frame delay at the same interval without host v-sync (you'd just see tearing instead).

I added the [59,61] range check on host frame rate per Brett's suggestion, though I tend to think an explicit config option for enabling host v-sync would be more appropriate.

Note that I don't really grok std::chrono, so there may be a better way to write the decafSwapBuffers() delay logic.

(This PR includes #293 since GitHub doesn't seem to allow a PR comparing between two branches of a different fork.)