### PR TITLE
opengl: Give transform feedback blocks unique names.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -982,7 +982,7 @@ bool GLDriver::compileVertexShader(VertexShader &vertex, FetchShader &fetch, uin
          out
             << "layout(xfb_buffer = " << buffer
             << ", xfb_stride = " << stride
-            << ") out block {\n";
+            << ") out feedback_block" << buffer << " {\n";
 
          for (auto &xfb : shader.feedbacks[buffer]) {
             out << "   layout(xfb_offset = " << xfb.offset << ") out ";


### PR DESCRIPTION
GLSL requires a block identifier, not just the keyword "block".