### PR TITLE
gx2: Add missing GX2Invalidate() on newly created fetch shaders.

### DIFF
--- a/src/libdecaf/src/modules/gx2/gx2_fetchshader.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_fetchshader.cpp
@@ -2,6 +2,7 @@
 #include "gx2_enum.h"
 #include "gx2_enum_string.h"
 #include "gx2_format.h"
+#include "gx2_mem.h"
 #include "gpu/microcode/latte_instructions.h"
 #include "common/align.h"
 #include "common/decaf_assert.h"
@@ -451,6 +452,8 @@ GX2InitFetchShaderEx(GX2FetchShader *fetchShader,
    sq_pgm_resources_fs = sq_pgm_resources_fs
       .NUM_GPRS(numGPRs);
    fetchShader->regs.sq_pgm_resources_fs = sq_pgm_resources_fs;
+
+   GX2Invalidate(GX2InvalidateMode::CPU, fetchShader->data, fetchShader->size);
 }
 
 } // namespace gx2


### PR DESCRIPTION
gx2.rpl sez:
```
01154b58 <GX2InitFetchShaderEx>:
 1154b58:       7c 08 02 a6     mflr    r0
 1154b5c:       94 21 ff 98     stwu    r1,-104(r1)
 1154b60:       90 01 00 6c     stw     r0,108(r1)
 1154b64:       7c ea 3b 78     mr      r10,r7
 1154b68:       bd e1 00 24     stmw    r15,36(r1)
 1154b6c:       7c 7e 1b 78     mr      r30,r3
...
 1155264:       80 9e 00 0c     lwz     r4,12(r30)
...
 1155278:       80 be 00 08     lwz     r5,8(r30)
 115527c:       91 41 00 1c     stw     r10,28(r1)
 1155280:       38 60 00 40     li      r3,64
 1155284:       93 3e 00 04     stw     r25,4(r30)
 1155288:       48 00 23 39     bl      11575c0 <GX2Invalidate>
```