### PR TITLE
opengl: Exclude degamma from surface key.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_surface.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_surface.cpp
@@ -692,7 +692,7 @@ GLDriver::getSurfaceBuffer(ppcaddr_t baseAddress,
    //  are compatible across.  Note that at some point, we may
    //  need to make format not be part of the key as well...
    auto surfaceKey = static_cast<uint64_t>(baseAddress) << 32;
-   surfaceKey ^= format << 22 ^ numFormat << 28 ^ formatComp << 30 ^ degamma << 31;
+   surfaceKey ^= format << 22 ^ numFormat << 28 ^ formatComp << 30;
 
    switch (dim) {
    case latte::SQ_TEX_DIM_1D:


### PR DESCRIPTION
This partly fixes the Xenoblade character creation screen, which renders the world to a surface in RGB mode and then reads from the same surface in SRGB mode; the circular floor is now a real floor instead of a black hole. The remaining problem (white glare) seems to be some sort of HDR math glitch, which I'm still looking into.