### PR TITLE
opengl: Surface-related fixes.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
@@ -68,7 +68,7 @@ bool GLDriver::checkActiveColorBuffer()
          }
 
          // Bind color buffer i
-         active = getColorBuffer(cb_color_base, cb_color_size, cb_color_info);
+         active = getColorBuffer(cb_color_base, cb_color_size, cb_color_info, false);
          gl::glFramebufferTexture(gl::GL_FRAMEBUFFER, gl::GL_COLOR_ATTACHMENT0 + i, active->active->object, 0);
 
          // Apply channel mask
@@ -90,7 +90,8 @@ bool GLDriver::checkActiveColorBuffer()
 SurfaceBuffer *
 GLDriver::getColorBuffer(latte::CB_COLORN_BASE cb_color_base,
                          latte::CB_COLORN_SIZE cb_color_size,
-                         latte::CB_COLORN_INFO cb_color_info)
+                         latte::CB_COLORN_INFO cb_color_info,
+                         bool discardData)
 {
    auto baseAddress = (cb_color_base.BASE_256B << 8) & 0xFFFFF800;
    auto pitch_tile_max = cb_color_size.PITCH_TILE_MAX();
@@ -144,7 +145,7 @@ GLDriver::getColorBuffer(latte::CB_COLORN_BASE cb_color_base,
 
    auto tileMode = getArrayModeTileMode(cb_color_info.ARRAY_MODE());
 
-   auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, false, tileMode, true);
+   auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, false, tileMode, true, discardData);
    gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_MAG_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_MIN_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_WRAP_S, static_cast<int>(gl::GL_CLAMP_TO_EDGE));

--- a/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
@@ -40,7 +40,7 @@ bool GLDriver::checkActiveDepthBuffer()
    }
 
    // Bind depth buffer
-   active = getDepthBuffer(db_depth_base, db_depth_size, db_depth_info);
+   active = getDepthBuffer(db_depth_base, db_depth_size, db_depth_info, false);
    auto dbFormat = db_depth_info.FORMAT();
    if (dbFormat == latte::DEPTH_8_24
     || dbFormat == latte::DEPTH_8_24_FLOAT
@@ -60,7 +60,8 @@ bool GLDriver::checkActiveDepthBuffer()
 SurfaceBuffer *
 GLDriver::getDepthBuffer(latte::DB_DEPTH_BASE db_depth_base,
                          latte::DB_DEPTH_SIZE db_depth_size,
-                         latte::DB_DEPTH_INFO db_depth_info)
+                         latte::DB_DEPTH_INFO db_depth_info,
+                         bool discardData)
 {
    auto baseAddress = (db_depth_base.BASE_256B << 8) & 0xFFFFF800;
    auto pitch_tile_max = db_depth_size.PITCH_TILE_MAX();
@@ -115,7 +116,7 @@ GLDriver::getDepthBuffer(latte::DB_DEPTH_BASE db_depth_base,
 
    auto tileMode = getArrayModeTileMode(db_depth_info.ARRAY_MODE());
 
-   auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, true, tileMode, true);
+   auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, true, tileMode, true, discardData);
    gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_MAG_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_MIN_FILTER, static_cast<int>(gl::GL_NEAREST));
    gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_WRAP_S, static_cast<int>(gl::GL_CLAMP_TO_EDGE));

--- a/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
@@ -359,7 +359,7 @@ GLDriver::decafClearColor(const pm4::DecafClearColor &data)
 
    // Find our colorbuffer to clear
    auto cb_color_base = bit_cast<latte::CB_COLORN_BASE>(data.bufferAddr);
-   auto buffer = getColorBuffer(cb_color_base, data.cb_color_size, data.cb_color_info);
+   auto buffer = getColorBuffer(cb_color_base, data.cb_color_size, data.cb_color_info, true);
 
    // Bind color buffer
    gl::glNamedFramebufferTexture(mColorClearFrameBuffer, gl::GL_COLOR_ATTACHMENT0, buffer->active->object, 0);
@@ -394,7 +394,7 @@ GLDriver::decafClearDepthStencil(const pm4::DecafClearDepthStencil &data)
 
    // Find our depthbuffer to clear
    auto db_depth_base = bit_cast<latte::DB_DEPTH_BASE>(data.bufferAddr);
-   auto buffer = getDepthBuffer(db_depth_base, data.db_depth_size, data.db_depth_info);
+   auto buffer = getDepthBuffer(db_depth_base, data.db_depth_size, data.db_depth_info, true);
 
    // Bind depth buffer
    if (hasStencil) {

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -114,7 +114,7 @@ void
 GLDriver::decafCopyColorToScan(const pm4::DecafCopyColorToScan &data)
 {
    auto cb_color_base = bit_cast<latte::CB_COLORN_BASE>(data.bufferAddr);
-   auto buffer = getColorBuffer(cb_color_base, data.cb_color_size, data.cb_color_info);
+   auto buffer = getColorBuffer(cb_color_base, data.cb_color_size, data.cb_color_info, false);
    ScanBufferChain *target = nullptr;
 
    if (data.scanTarget == SCANTARGET_TV) {
@@ -248,6 +248,7 @@ GLDriver::decafCopySurface(const pm4::DecafCopySurface &data)
       data.dstDegamma,
       false,
       data.dstTileMode,
+      true,
       true);
 
    auto srcBuffer = getSurfaceBuffer(
@@ -263,6 +264,7 @@ GLDriver::decafCopySurface(const pm4::DecafCopySurface &data)
       data.srcDegamma,
       false,
       data.srcTileMode,
+      false,
       false);
 
    gl::glCopyImageSubData(

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -34,6 +34,7 @@ GLDriver::initGL()
    mActiveShader = nullptr;
    mActiveDepthBuffer = nullptr;
    memset(&mActiveColorBuffers[0], 0, sizeof(SurfaceBuffer *) * mActiveColorBuffers.size());
+   mDrawBuffers.fill(gl::GL_NONE);
 
    // Create our blit framebuffer
    gl::glCreateFramebuffers(2, mBlitFrameBuffers);

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -32,8 +32,6 @@ GLDriver::initGL()
       applyRegister(static_cast<latte::Register>(i*4));
    }
    mActiveShader = nullptr;
-   mActiveDepthBuffer = nullptr;
-   memset(&mActiveColorBuffers[0], 0, sizeof(SurfaceBuffer *) * mActiveColorBuffers.size());
    mDrawBuffers.fill(gl::GL_NONE);
 
    // Create our blit framebuffer

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "common/platform.h"
 #include "common/log.h"
+#include "glsl2_translate.h"
 #include "gpu/pm4.h"
 #include "gpu/latte_constants.h"
 #include "gpu/latte_contextstate.h"
@@ -25,14 +26,6 @@ namespace gpu
 
 namespace opengl
 {
-
-enum class SamplerType
-{
-   Invalid,
-   Sampler1D,
-   Sampler2D,
-   Sampler2DArray,
-};
 
 enum class SurfaceUseState : uint32_t
 {
@@ -91,8 +84,8 @@ struct PixelShader : public Resource
    gl::GLuint object = 0;
    gl::GLuint uniformRegisters = 0;
    gl::GLuint uniformAlphaRef = 0;
-   std::array<SamplerType, latte::MaxSamplers> samplerTypes;
    latte::SX_ALPHA_TEST_CONTROL sx_alpha_test_control;
+   std::array<glsl2::SamplerUsage, latte::MaxSamplers> samplerUsage;
    std::array<bool, 16> usedUniformBlocks;
    std::string code;
    std::string disassembly;

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -156,17 +156,13 @@ struct Sampler
 
 struct ColorBufferCache
 {
-   uint32_t base = 0;
-   uint32_t size = 0;
-   uint32_t info = 0;
+   gl::GLuint object = 0;
    uint32_t mask = 0;
 };
 
 struct DepthBufferCache
 {
-   uint32_t base = 0;
-   uint32_t size = 0;
-   uint32_t info = 0;
+   gl::GLuint object = 0;
 };
 
 struct TextureCache
@@ -387,8 +383,6 @@ private:
    gl::GLuint mColorClearFrameBuffer;
    gl::GLuint mDepthClearFrameBuffer;
    Shader *mActiveShader = nullptr;
-   SurfaceBuffer *mActiveDepthBuffer = nullptr;
-   std::array<SurfaceBuffer *, latte::MaxRenderTargets> mActiveColorBuffers;
    std::array<gl::GLenum, latte::MaxRenderTargets> mDrawBuffers;
    ScanBufferChain mTvScanBuffers;
    ScanBufferChain mDrcScanBuffers;

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -289,17 +289,20 @@ private:
                     uint32_t degamma,
                     bool isDepthBuffer,
                     latte::SQ_TILE_MODE tileMode,
-                    bool forWrite);
+                    bool forWrite,
+                    bool discardData);
 
    SurfaceBuffer *
    getColorBuffer(latte::CB_COLORN_BASE base,
                   latte::CB_COLORN_SIZE size,
-                  latte::CB_COLORN_INFO info);
+                  latte::CB_COLORN_INFO info,
+                  bool discardData);
 
    SurfaceBuffer *
    getDepthBuffer(latte::DB_DEPTH_BASE db_depth_base,
                   latte::DB_DEPTH_SIZE db_depth_size,
-                  latte::DB_DEPTH_INFO db_depth_info);
+                  latte::DB_DEPTH_INFO db_depth_info,
+                  bool discardData);
 
    bool checkReadyDraw();
    bool checkActiveAttribBuffers();

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -386,6 +386,7 @@ private:
    Shader *mActiveShader = nullptr;
    SurfaceBuffer *mActiveDepthBuffer = nullptr;
    std::array<SurfaceBuffer *, latte::MaxRenderTargets> mActiveColorBuffers;
+   std::array<gl::GLenum, latte::MaxRenderTargets> mDrawBuffers;
    ScanBufferChain mTvScanBuffers;
    ScanBufferChain mDrcScanBuffers;
 

--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -1326,6 +1326,7 @@ bool GLDriver::compilePixelShader(PixelShader &pixel, VertexShader &vertex, uint
       return false;
    }
 
+   pixel.samplerUsage = shader.samplerUsage;
    pixel.usedUniformBlocks = shader.usedUniformBlocks;
 
    fmt::MemoryWriter out;

--- a/src/libdecaf/src/gpu/opengl/opengl_texture.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_texture.cpp
@@ -86,7 +86,7 @@ bool GLDriver::checkActiveTextures()
       decaf_check((baseAddress & 0x7FF) == swizzle);
 
       // Get the surface
-      auto buffer = getSurfaceBuffer(baseAddress, pitch, width, height, depth, dim, format, numFormat, formatComp, degamma, isDepthBuffer, tileMode, false);
+      auto buffer = getSurfaceBuffer(baseAddress, pitch, width, height, depth, dim, format, numFormat, formatComp, degamma, isDepthBuffer, tileMode, false, false);
 
       if (buffer->active->object != mPixelTextureCache[i].surfaceObject
        || sq_tex_resource_word4.value != mPixelTextureCache[i].word4) {


### PR DESCRIPTION
You don't actually want to merge this yet -- bdaaee9 requires 710fc55 from #302 (also on this branch because the following patches are based on it), so it likewise won't compile without #303 merged. #294 is also needed for correct rendering, though the change itself doesn't conflict with anything here.