### PR TITLE
opengl: Implement the JUMP shader instruction.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_translate.cpp
@@ -732,6 +732,15 @@ translate(Shader &shader, const gsl::span<const uint8_t> &binary)
 
    try {
       for (auto i = 0; i < binary.size(); i += sizeof(ControlFlowInst)) {
+         while (!state.jumpStack.empty() && state.cfPC == state.jumpStack.top().toPC) {
+            decreaseIndent(state);
+            insertLineStart(state);
+            state.out << '}';
+            insertLineEnd(state);
+
+            state.jumpStack.pop();
+         }
+
          auto cf = *reinterpret_cast<const ControlFlowInst *>(binary.data() + i);
          auto id = cf.word1.CF_INST();
 

--- a/src/libdecaf/src/gpu/opengl/glsl2_translate.h
+++ b/src/libdecaf/src/gpu/opengl/glsl2_translate.h
@@ -78,6 +78,12 @@ struct LoopState
    uint32_t endPC;
 };
 
+struct JumpState
+{
+   uint32_t fromPC;
+   uint32_t toPC;
+};
+
 struct State
 {
    Shader *shader = nullptr;
@@ -92,6 +98,7 @@ struct State
    gsl::span<const uint32_t> literals;
    std::vector<std::string> postGroupWrites;
    std::stack<LoopState> loopStack;
+   std::stack<JumpState> jumpStack;
    bool printMyCode = false;
 };
 


### PR DESCRIPTION
Treating it as a no-op and letting the active tests on ALU blocks deal with it only works as long as there are no nested conditionals; we have to honor a JUMP that jumps over a nested JUMP/ELSE.