### PR TITLE
decaf-sdl: Allow filtering out specific OpenGL debug messages by ID.

### DIFF
--- a/src/decaf-sdl/config.cpp
+++ b/src/decaf-sdl/config.cpp
@@ -87,8 +87,9 @@ struct CerealGPU
    {
       using namespace gpu;
       using namespace decaf::config::gpu;
-      ar(CEREAL_NVP(force_sync),
-         CEREAL_NVP(debug));
+      ar(CEREAL_NVP(debug),
+         CEREAL_NVP(debug_filters),
+         CEREAL_NVP(force_sync));
    }
 };
 

--- a/src/decaf-sdl/decafsdl_draw.cpp
+++ b/src/decaf-sdl/decafsdl_draw.cpp
@@ -74,6 +74,12 @@ static void GL_APIENTRY
 debugMessageCallback(gl::GLenum source, gl::GLenum type, gl::GLuint id, gl::GLenum severity,
                      gl::GLsizei length, const gl::GLchar* message, const void *userParam)
 {
+   for (auto filterID : decaf::config::gpu::debug_filters) {
+      if (filterID == id) {
+         return;
+      }
+   }
+
    auto outputStr = fmt::format("GL Message ({}, {}, {}, {}) {}", id,
       getGlDebugSource(source),
       getGlDebugType(type),

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <set>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,10 @@ namespace gpu
 
 //! Enable OpenGL debugging
 extern bool debug;
+
+//! OpenGL debug message IDs to filter out
+// TODO: should really be a std::set, but cereal doesn't support those...
+extern std::vector<unsigned> debug_filters;
 
 }
 
@@ -58,7 +63,7 @@ extern bool kernel_trace;
 //! Enable logging of every branch which targets a known symbol
 extern bool branch_trace;
 
-//! RegEx filters for kernel trace function name matching
+//! Wildcard filters for kernel trace function name matching
 extern std::vector<std::string> kernel_trace_filters;
 
 } // namespace log

--- a/src/libdecaf/src/decaf_config.cpp
+++ b/src/libdecaf/src/decaf_config.cpp
@@ -19,6 +19,7 @@ namespace gpu
 {
 
 bool debug = false;
+std::vector<unsigned> debug_filters = {};
 
 } // namespace gpu
 


### PR DESCRIPTION
If you're using the Nvidia driver, you really really want `"debug_filters": [131185]` because SPAM.