### PR TITLE
opengl: Avoid unnecessary calls to glTextureParameteri().

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
@@ -133,10 +133,6 @@ GLDriver::getColorBuffer(latte::CB_COLORN_BASE cb_color_base,
    auto tileMode = getArrayModeTileMode(cb_color_info.ARRAY_MODE());
 
    auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, false, tileMode, true, discardData);
-   gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_MAG_FILTER, static_cast<int>(gl::GL_NEAREST));
-   gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_MIN_FILTER, static_cast<int>(gl::GL_NEAREST));
-   gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_WRAP_S, static_cast<int>(gl::GL_CLAMP_TO_EDGE));
-   gl::glTextureParameteri(buffer->active->object, gl::GL_TEXTURE_WRAP_T, static_cast<int>(gl::GL_CLAMP_TO_EDGE));
 
    buffer->dirtyAsTexture = false;
    buffer->state = SurfaceUseState::GpuWritten;

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -112,6 +112,10 @@ struct HostSurface
    uint32_t depth = 0;
    uint32_t degamma = false;
    bool isDepthBuffer = false;
+   gl::GLenum swizzleR;
+   gl::GLenum swizzleG;
+   gl::GLenum swizzleB;
+   gl::GLenum swizzleA;
    HostSurface *next = nullptr;
 };
 
@@ -288,6 +292,13 @@ private:
                     latte::SQ_TILE_MODE tileMode,
                     bool forWrite,
                     bool discardData);
+
+   void
+   setSurfaceSwizzle(SurfaceBuffer *surface,
+                     gl::GLenum swizzleR,
+                     gl::GLenum swizzleG,
+                     gl::GLenum swizzleB,
+                     gl::GLenum swizzleA);
 
    SurfaceBuffer *
    getColorBuffer(latte::CB_COLORN_BASE base,

--- a/src/libdecaf/src/gpu/opengl/opengl_surface.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_surface.cpp
@@ -428,6 +428,10 @@ createHostSurface(ppcaddr_t baseAddress,
    newSurface->depth = depth;
    newSurface->degamma = degamma;
    newSurface->isDepthBuffer = isDepthBuffer;
+   newSurface->swizzleR = gl::GL_RED;
+   newSurface->swizzleG = gl::GL_GREEN;
+   newSurface->swizzleB = gl::GL_BLUE;
+   newSurface->swizzleA = gl::GL_ALPHA;
    newSurface->next = nullptr;
    return newSurface;
 }
@@ -865,6 +869,36 @@ GLDriver::getSurfaceBuffer(ppcaddr_t baseAddress,
    }
 
    return &buffer;
+}
+
+void
+GLDriver::setSurfaceSwizzle(SurfaceBuffer *surface,
+                            gl::GLenum swizzleR,
+                            gl::GLenum swizzleG,
+                            gl::GLenum swizzleB,
+                            gl::GLenum swizzleA)
+{
+   HostSurface *host = surface->active;
+   decaf_check(host);
+
+   if (swizzleR != host->swizzleR
+    || swizzleG != host->swizzleG
+    || swizzleB != host->swizzleB
+    || swizzleA != host->swizzleA) {
+      host->swizzleR = swizzleR;
+      host->swizzleG = swizzleG;
+      host->swizzleB = swizzleB;
+      host->swizzleA = swizzleA;
+
+      gl::GLint textureSwizzle[] = {
+         static_cast<gl::GLint>(swizzleR),
+         static_cast<gl::GLint>(swizzleG),
+         static_cast<gl::GLint>(swizzleB),
+         static_cast<gl::GLint>(swizzleA),
+      };
+
+      gl::glTextureParameteriv(host->object, gl::GL_TEXTURE_SWIZZLE_RGBA, textureSwizzle);
+   }
 }
 
 } // namespace opengl

--- a/src/libdecaf/src/gpu/opengl/opengl_texture.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_texture.cpp
@@ -99,14 +99,7 @@ bool GLDriver::checkActiveTextures()
          auto dst_sel_z = getTextureSwizzle(sq_tex_resource_word4.DST_SEL_Z());
          auto dst_sel_w = getTextureSwizzle(sq_tex_resource_word4.DST_SEL_W());
 
-         gl::GLint textureSwizzle[] = {
-            static_cast<gl::GLint>(dst_sel_x),
-            static_cast<gl::GLint>(dst_sel_y),
-            static_cast<gl::GLint>(dst_sel_z),
-            static_cast<gl::GLint>(dst_sel_w),
-         };
-
-         gl::glTextureParameteriv(buffer->active->object, gl::GL_TEXTURE_SWIZZLE_RGBA, textureSwizzle);
+         setSurfaceSwizzle(buffer, dst_sel_x, dst_sel_y, dst_sel_z, dst_sel_w);
 
          // In debug mode, first unbind the unit to remove any textures of
          //  different types (again, to reduce clutter in apitrace etc.)


### PR DESCRIPTION
This nearly halved the number of GL calls on the Xenoblade title screen...