### PR TITLE
opengl: Use DCFlush()/DCStore() as the dirty-resource signal.

### DIFF
--- a/src/libdecaf/decaf_graphics.h
+++ b/src/libdecaf/decaf_graphics.h
@@ -15,6 +15,8 @@ public:
    virtual void run() = 0;
    virtual void stop() = 0;
    virtual float getAverageFPS() = 0;
+
+   virtual void handleDCFlush(uint32_t addr, uint32_t size) = 0;  // May be called from any thread!
 };
 
 class OpenGLDriver : public GraphicsDriver

--- a/src/libdecaf/decaf_nullgraphicsdriver.cpp
+++ b/src/libdecaf/decaf_nullgraphicsdriver.cpp
@@ -40,6 +40,11 @@ NullGraphicsDriver::getAverageFPS()
    return 0.0f;
 }
 
+void
+NullGraphicsDriver::handleDCFlush(uint32_t addr, uint32_t size)
+{
+}
+
 OpenGLDriver *
 createGLDriver()
 {

--- a/src/libdecaf/decaf_nullgraphicsdriver.h
+++ b/src/libdecaf/decaf_nullgraphicsdriver.h
@@ -12,6 +12,7 @@ public:
    virtual void run() override;
    virtual void stop() override;
    virtual float getAverageFPS() override;
+   virtual void handleDCFlush(uint32_t addr, uint32_t size) override;
 
 private:
    bool mRunning = false;

--- a/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_colorbuffer.cpp
@@ -139,7 +139,8 @@ GLDriver::getColorBuffer(latte::CB_COLORN_BASE cb_color_base,
 
    auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, false, tileMode, true, discardData);
 
-   buffer->dirtyAsTexture = false;
+   buffer->dirtyMemory = false;
+   buffer->needUpload = false;
    buffer->state = SurfaceUseState::GpuWritten;
    return buffer;
 }

--- a/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
@@ -135,7 +135,8 @@ GLDriver::getDepthBuffer(latte::DB_DEPTH_BASE db_depth_base,
 
    auto buffer = getSurfaceBuffer(baseAddress, pitch, pitch, height, 1, latte::SQ_TEX_DIM_2D, format, numFormat, formatComp, degamma, true, tileMode, true, discardData);
 
-   buffer->dirtyAsTexture = false;
+   buffer->dirtyMemory = false;
+   buffer->needUpload = false;
    buffer->state = SurfaceUseState::GpuWritten;
    return buffer;
 }

--- a/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_draw.cpp
@@ -459,7 +459,9 @@ GLDriver::streamOutBufferUpdate(const pm4::StreamOutBufferUpdate &data)
    auto size = vgt_strmout_buffer_size << 2;
    decaf_assert(addr != 0 && size != 0, fmt::format("Attempt to bind undefined feedback buffer {}", bufferIndex));
 
-   configureDataBuffer(&mDataBuffers[addr], addr, size, false, true);
+   // Create the data buffer (we don't need to manipulate it here, but
+   //  make sure it's configured as an output buffer)
+   getDataBuffer(addr, size, false, true);
 
    switch (data.control.OFFSET_SOURCE()) {
    case pm4::STRMOUT_OFFSET_FROM_PACKET:

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -287,12 +287,14 @@ GLDriver::decafCopySurface(const pm4::DecafCopySurface &data)
       copyHeight,
       copyDepth);
 
-   dstBuffer->dirtyAsTexture = false;
+   dstBuffer->needUpload = false;
 }
 
 void
 GLDriver::surfaceSync(const pm4::SurfaceSync &data)
 {
+   std::unique_lock<std::mutex> lock(mResourceMutex);
+
    auto memStart = data.addr << 8;
    auto memEnd = memStart + (data.size << 8);
 
@@ -322,29 +324,34 @@ GLDriver::surfaceSync(const pm4::SurfaceSync &data)
    }
 
    if (surfaces) {
-      for (auto &surf : mSurfaces) {
-         if (surf.second.cpuMemStart >= memEnd || surf.second.cpuMemEnd < memStart) {
+      for (auto &i : mSurfaces) {
+         SurfaceBuffer *surface = &i.second;
+
+         if (surface->cpuMemStart >= memEnd || surface->cpuMemEnd < memStart) {
             continue;
          }
 
-         surf.second.dirtyAsTexture = true;
+         surface->needUpload |= surface->dirtyMemory;
+         surface->dirtyMemory = false;
       }
    }
 
-   for (auto &buffer : mDataBuffers) {
-      DataBuffer *dataBuffer = &buffer.second;
+   for (auto &i : mDataBuffers) {
+      DataBuffer *buffer = &i.second;
 
-      if (dataBuffer->cpuMemStart >= memEnd || dataBuffer->cpuMemEnd < memStart) {
+      if (buffer->cpuMemStart >= memEnd || buffer->cpuMemEnd < memStart) {
          continue;
       }
 
-      auto offset = std::max(memStart, dataBuffer->cpuMemStart) - dataBuffer->cpuMemStart;
-      auto size = (std::min(memEnd, dataBuffer->cpuMemEnd) - dataBuffer->cpuMemStart) - offset;
+      auto offset = std::max(memStart, buffer->cpuMemStart) - buffer->cpuMemStart;
+      auto size = (std::min(memEnd, buffer->cpuMemEnd) - buffer->cpuMemStart) - offset;
 
-      if (dataBuffer->isOutput && shaderExport) {
-         downloadDataBuffer(dataBuffer, offset, size);
-      } else if (dataBuffer->isInput && (shader || surfaces)) {
-         uploadDataBuffer(dataBuffer, offset, size);
+      if (buffer->isOutput && shaderExport) {
+         downloadDataBuffer(buffer, offset, size);
+         buffer->dirtyMemory = false;
+      } else if (buffer->isInput && buffer->dirtyMemory && (shader || surfaces)) {
+         uploadDataBuffer(buffer, offset, size);
+         buffer->dirtyMemory = false;
       }
    }
 }
@@ -529,6 +536,35 @@ GLDriver::executeBuffer(pm4::Buffer *buffer)
 
    // Release command buffer
    gpu::retireCommandBuffer(buffer);
+}
+
+void
+GLDriver::handleDCFlush(uint32_t addr, uint32_t size)
+{
+   std::unique_lock<std::mutex> lock(mResourceMutex);
+
+   auto memStart = addr;
+   auto memEnd = memStart + size;
+
+   for (auto &i : mSurfaces) {
+      SurfaceBuffer *surface = &i.second;
+
+      if (surface->cpuMemStart >= memEnd || surface->cpuMemEnd < memStart) {
+         continue;
+      }
+
+      surface->dirtyMemory = true;
+   }
+
+   for (auto &i : mDataBuffers) {
+      DataBuffer *buffer = &i.second;
+
+      if (buffer->cpuMemStart >= memEnd || buffer->cpuMemEnd < memStart) {
+         continue;
+      }
+
+      buffer->dirtyMemory = true;
+   }
 }
 
 void

--- a/src/libdecaf/src/modules/coreinit/coreinit_cache.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_cache.cpp
@@ -1,6 +1,7 @@
 #include "coreinit.h"
 #include "coreinit_cache.h"
 #include "common/align.h"
+#include "decaf_graphics.h"
 
 namespace coreinit
 {
@@ -23,6 +24,9 @@ void
 DCFlushRange(void *addr, uint32_t size)
 {
    // TODO: DCFlushRange
+
+   // Also signal the memory store to the GPU.
+   decaf::getGraphicsDriver()->handleDCFlush(mem::untranslate(addr), size);
 }
 
 
@@ -33,6 +37,9 @@ void
 DCStoreRange(void *addr, uint32_t size)
 {
    // TODO: DCStoreRange
+
+   // Also signal the memory store to the GPU.
+   decaf::getGraphicsDriver()->handleDCFlush(mem::untranslate(addr), size);
 }
 
 

--- a/src/libdecaf/src/modules/coreinit/coreinit_lockedcache.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_lockedcache.cpp
@@ -1,10 +1,11 @@
-#include <array>
+#include "common/teenyheap.h"
 #include "coreinit.h"
 #include "coreinit_core.h"
 #include "coreinit_lockedcache.h"
 #include "coreinit_thread.h"
+#include "decaf_graphics.h"
 #include "libcpu/mem.h"
-#include "common/teenyheap.h"
+#include <array>
 
 namespace coreinit
 {
@@ -171,6 +172,9 @@ LCStoreDMABlocks(void *dst, const void *src, uint32_t size)
    }
 
    std::memcpy(dst, src, size * 32);
+
+   // Also signal the memory store to the GPU, as with DCFlushRange().
+   decaf::getGraphicsDriver()->handleDCFlush(mem::untranslate(dst), size);
 }
 
 


### PR DESCRIPTION
For well-behaved games, this is sufficient to cover all GPU resource updates from the CPU side (modulo shaders, which I'll PR next). If any games are non-well-behaved and still happen to work on real hardware, that's probably the sort of thing that has to be handled on a case-by-case basis, like race conditions that happen to never be hit on a real 750CL or such...