### PR TITLE
opengl: Invert handling of DX_CLIP_SPACE_DEF in PA_CL_CLIP_CNTL.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_registers.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_registers.cpp
@@ -262,9 +262,9 @@ GLDriver::applyRegister(latte::Register reg)
       }
 
       if (pa_cl_clip_cntl.DX_CLIP_SPACE_DEF()) {
-         gl::glClipControl(gl::GL_UPPER_LEFT, gl::GL_NEGATIVE_ONE_TO_ONE);
-      } else {
          gl::glClipControl(gl::GL_UPPER_LEFT, gl::GL_ZERO_TO_ONE);
+      } else {
+         gl::glClipControl(gl::GL_UPPER_LEFT, gl::GL_NEGATIVE_ONE_TO_ONE);
       }
    } break;
 


### PR DESCRIPTION
The OpenGL API docs for glClipControl explicitly give the example of DirectX as a use case for GL_ZERO_TO_ONE, and Mesa includes the expression S_028810_DX_CLIP_SPACE_DEF(state->clip_halfz) when computing the PA_CL_CLIP_CNTL register value (note the "halfz"), so I suspect the current logic is backwards.