### PR TITLE
opengl: Invert handling of ZCLIP_NEAR_DISABLE in PA_CL_CLIP_CNTL.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_registers.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_registers.cpp
@@ -255,10 +255,12 @@ GLDriver::applyRegister(latte::Register reg)
          gl::glDisable(gl::GL_RASTERIZER_DISCARD);
       }
 
+      decaf_assert(pa_cl_clip_cntl.ZCLIP_NEAR_DISABLE() == pa_cl_clip_cntl.ZCLIP_FAR_DISABLE(),
+                   fmt::format("Inconsistent near/far depth clamp setting"));
       if (pa_cl_clip_cntl.ZCLIP_NEAR_DISABLE()) {
-         gl::glDisable(gl::GL_DEPTH_CLAMP);
-      } else {
          gl::glEnable(gl::GL_DEPTH_CLAMP);
+      } else {
+         gl::glDisable(gl::GL_DEPTH_CLAMP);
       }
 
       if (pa_cl_clip_cntl.DX_CLIP_SPACE_DEF()) {


### PR DESCRIPTION
I had to read over the API docs and Mesa code several times to get this straight, but I _think_ the current code is backwards: the GL meaning of "clamp" is that primitives are not clipped and instead the depth values are clamped to the depth buffer range when they're stored. Mesa also has
```
pa_cl_clip_cntl = ... | S_028810_ZCLIP_NEAR_DISABLE(!state->depth_clip) | ...
```
and the note "depth_clip == 0 implies depth clamping is enabled."