### PR TITLE
opengl: Avoid repetitive glEnable(GL_PRIMITIVE_RESTART) calls.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -34,6 +34,9 @@ GLDriver::initGL()
    mActiveShader = nullptr;
    mDrawBuffers.fill(gl::GL_NONE);
 
+   // Primitive restart appears to always be enabled on the GX2
+   gl::glEnable(gl::GL_PRIMITIVE_RESTART);
+
    // Create our blit framebuffer
    gl::glCreateFramebuffers(2, mBlitFrameBuffers);
    if (decaf::config::gpu::debug) {

--- a/src/libdecaf/src/gpu/opengl/opengl_registers.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_registers.cpp
@@ -254,7 +254,6 @@ GLDriver::applyRegister(latte::Register reg)
    case latte::Register::VGT_MULTI_PRIM_IB_RESET_INDX:
    {
       auto vgt_multi_prim_ib_reset_indx = *reinterpret_cast<latte::VGT_MULTI_PRIM_IB_RESET_INDX*>(&value);
-      gl::glEnable(gl::GL_PRIMITIVE_RESTART);
       gl::glPrimitiveRestartIndex(vgt_multi_prim_ib_reset_indx.RESET_INDX);
    } break;
 


### PR DESCRIPTION
If it is permanently enabled, there's no reason to re-enable the GL state on every register write.

Could also be that the register just has a default value of 1 instead of 0, but I don't have a good way to test graphics code on hardware at the moment.