### PR TITLE
opengl: Disable early fragment tests for shaders which use discard.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/glsl2_alu_op2.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_alu_op2.cpp
@@ -271,6 +271,8 @@ binaryCompareKill(State &state,
    insertLineStart(state);
    state.out << '}';
    insertLineEnd(state);
+
+   state.shader->usesDiscard = true;
 }
 
 static void

--- a/src/libdecaf/src/gpu/opengl/glsl2_cf.cpp
+++ b/src/libdecaf/src/gpu/opengl/glsl2_cf.cpp
@@ -56,6 +56,8 @@ KILL(State &state, const ControlFlowInst &cf)
    insertLineStart(state);
    state.out << "discard;";
    insertLineEnd(state);
+
+   state.shader->usesDiscard = true;
 }
 
 static void

--- a/src/libdecaf/src/gpu/opengl/glsl2_translate.h
+++ b/src/libdecaf/src/gpu/opengl/glsl2_translate.h
@@ -70,6 +70,7 @@ struct Shader
    std::array<std::vector<Feedback>, latte::MaxStreamOutBuffers> feedbacks;
    std::array<SamplerUsage, latte::MaxSamplers> samplerUsage;
    std::array<bool, latte::MaxUniformBlocks> usedUniformBlocks;
+   bool usesDiscard = false;
 };
 
 struct LoopState

--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -1351,11 +1351,17 @@ bool GLDriver::compilePixelShader(PixelShader &pixel, VertexShader &vertex, uint
    auto z_order = db_shader_control.Z_ORDER();
    auto early_z = (z_order == latte::DB_EARLY_Z_THEN_LATE_Z || z_order == latte::DB_EARLY_Z_THEN_RE_Z);
    if (early_z) {
-      for (auto &exp : shader.exports) {
-         if (exp.type == latte::SQ_EXPORT_PIXEL && exp.id == 61) {
-            gLog->warn("Ignoring early-Z because shader writes gl_FragDepth");
-            early_z = false;
-            break;
+      if (db_shader_control.KILL_ENABLE()) {
+         gLog->debug("Ignoring early-z because shader discard is enabled");
+         early_z = false;
+      } else {
+         decaf_assert(!shader.usesDiscard, "Shader uses discard but KILL_ENABLE is not set");
+         for (auto &exp : shader.exports) {
+            if (exp.type == latte::SQ_EXPORT_PIXEL && exp.id == 61) {
+               gLog->debug("Ignoring early-Z because shader writes gl_FragDepth");
+               early_z = false;
+               break;
+            }
          }
       }
       if (early_z) {


### PR DESCRIPTION
I suspect the way the hardware works wrt early-Z and discard is to disable early-Z whenever the KILL_ENABLE bit is set, but since we know for certain whether the fragment shader calls discard, I've used that knowledge instead. (I don't actually know what the GPU would do if a pixel shader has KILL instructions but the program doesn't set the KILL_ENABLE bit, but I imagine dev-side shader compilers take care of avoiding that.)

Fixes #331.