### PR TITLE
gpu: Remove flags from EVENT_WRITE high address word.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -441,8 +441,7 @@ GLDriver::eventWrite(const pm4::EventWrite &data)
       decaf_abort(fmt::format("Unexpected event type {}", type));
    }
 
-   switch (data.addrLo.ENDIAN_SWAP())
-   {
+   switch (data.addrLo.ENDIAN_SWAP()) {
    case latte::CB_ENDIAN_NONE:
       break;
    case latte::CB_ENDIAN_8IN64:
@@ -455,18 +454,7 @@ GLDriver::eventWrite(const pm4::EventWrite &data)
       decaf_abort("Unexpected EVENT_WRITE endian swap 8IN16");
    }
 
-   switch (data.addrHi.DATA_SEL()) {
-   case pm4::EW_DATA_DISCARD:
-      break;
-   case pm4::EW_DATA_32:
-      *reinterpret_cast<uint32_t *>(ptr) = static_cast<uint32_t>(value);
-      break;
-   case pm4::EW_DATA_64:
-      *reinterpret_cast<uint64_t *>(ptr) = value;
-      break;
-   case pm4::EW_DATA_CLOCK:
-      decaf_abort("Unexpected EW_DATA_CLOCK in EVENT_WRITE");
-   }
+   *reinterpret_cast<uint64_t *>(ptr) = value;
 }
 
 void
@@ -506,17 +494,17 @@ GLDriver::handlePendingEOP()
       value = byte_swap(static_cast<uint32_t>(value));
       break;
    case latte::CB_ENDIAN_8IN16:
-      decaf_abort(fmt::format("Unexpected EOP event endian swap {}", mPendingEOP.addrLo.ENDIAN_SWAP()));
+      decaf_abort("Unexpected EVENT_WRITE_EOP endian swap 8IN16");
    }
 
    switch (mPendingEOP.addrHi.DATA_SEL()) {
-   case pm4::EW_DATA_DISCARD:
+   case pm4::EWP_DATA_DISCARD:
       break;
-   case pm4::EW_DATA_32:
+   case pm4::EWP_DATA_32:
       *reinterpret_cast<uint32_t *>(ptr) = static_cast<uint32_t>(value);
       break;
-   case pm4::EW_DATA_64:
-   case pm4::EW_DATA_CLOCK:
+   case pm4::EWP_DATA_64:
+   case pm4::EWP_DATA_CLOCK:
       *reinterpret_cast<uint64_t *>(ptr) = value;
       break;
    }

--- a/src/libdecaf/src/gpu/pm4.h
+++ b/src/libdecaf/src/gpu/pm4.h
@@ -790,25 +790,8 @@ BITFIELD(EW_ADDR_LO, uint32_t)
    BITFIELD_ENTRY(2, 30, uint32_t, ADDR_LO);
 BITFIELD_END
 
-enum EW_DATA_SEL : uint32_t
-{
-   EW_DATA_DISCARD      = 0,
-   EW_DATA_32           = 1,
-   EW_DATA_64           = 2,
-   EW_DATA_CLOCK        = 3,
-};
-
-enum EW_INT_SEL : uint32_t
-{
-   EW_INT_NONE          = 0,
-   EW_INT_ONLY          = 1,
-   EW_INT_WRITE_CONFIRM = 2,
-};
-
 BITFIELD(EW_ADDR_HI, uint32_t)
    BITFIELD_ENTRY(0, 8, uint32_t, ADDR_HI);
-   BITFIELD_ENTRY(24, 2, EW_INT_SEL, INT_SEL);
-   BITFIELD_ENTRY(29, 3, EW_DATA_SEL, DATA_SEL);
 BITFIELD_END
 
 struct EventWrite
@@ -827,12 +810,33 @@ struct EventWrite
    }
 };
 
+enum EWP_DATA_SEL : uint32_t
+{
+   EWP_DATA_DISCARD      = 0,
+   EWP_DATA_32           = 1,
+   EWP_DATA_64           = 2,
+   EWP_DATA_CLOCK        = 3,
+};
+
+enum EWP_INT_SEL : uint32_t
+{
+   EWP_INT_NONE          = 0,
+   EWP_INT_ONLY          = 1,
+   EWP_INT_WRITE_CONFIRM = 2,
+};
+
+BITFIELD(EWP_ADDR_HI, uint32_t)
+   BITFIELD_ENTRY(0, 8, uint32_t, ADDR_HI);
+   BITFIELD_ENTRY(24, 2, EWP_INT_SEL, INT_SEL);
+   BITFIELD_ENTRY(29, 3, EWP_DATA_SEL, DATA_SEL);
+BITFIELD_END
+
 struct EventWriteEOP
 {
    static const auto Opcode = type3::EVENT_WRITE_EOP;
    latte::VGT_EVENT_INITIATOR eventInitiator;
    EW_ADDR_LO addrLo;
-   EW_ADDR_HI addrHi;
+   EWP_ADDR_HI addrHi;
    uint32_t dataLo;
    uint32_t dataHi;
 

--- a/src/libdecaf/src/modules/gx2/gx2_query.cpp
+++ b/src/libdecaf/src/modules/gx2/gx2_query.cpp
@@ -36,8 +36,8 @@ GX2SampleBottomGPUCycle(be_val<uint64_t> *result)
       .ADDR_LO(mem::untranslate(result) >> 2)
       .ENDIAN_SWAP(latte::CB_ENDIAN_8IN64);
 
-   auto addrHi = pm4::EW_ADDR_HI::get(0)
-      .DATA_SEL(pm4::EW_DATA_CLOCK);
+   auto addrHi = pm4::EWP_ADDR_HI::get(0)
+      .DATA_SEL(pm4::EWP_DATA_CLOCK);
 
    pm4::write(pm4::EventWriteEOP { eventInitiator, addrLo, addrHi, 0, 0 });
 }


### PR DESCRIPTION
Fixes dynamic objects on Xenoblade title screen not being rendered.

FWIW, Mesa's R600 driver suggests that addrHi has 16 valid bits of address, based on code like:
```
radeon_emit(cs, PKT3(PKT3_EVENT_WRITE, 2, 0));
radeon_emit(cs, EVENT_TYPE(EVENT_TYPE_ZPASS_DONE) | EVENT_INDEX(1));
radeon_emit(cs, va);
radeon_emit(cs, (va >> 32) & 0xFFFF);
```
But I don't know where the 8-bit field width came from, and it'll always be zero on the Wii U anyway, so I haven't touched that.