### PR TITLE
opengl: Use pack/unpack instructions for endian conversion in shaders.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_shader.cpp
@@ -946,8 +946,8 @@ bool GLDriver::compileVertexShader(VertexShader &vertex, FetchShader &fetch, uin
    fmt::MemoryWriter out;
    out << shader.fileHeader;
 
-   out << "#define bswap16(v) (((v & 0xFF00FF00) >> 8) | ((v & 0x00FF00FF) << 8))\n";
-   out << "#define bswap32(v) (((v & 0xFF000000) >> 24) | ((v & 0x00FF0000) >> 8) | ((v & 0x0000FF00) << 8) | ((v & 0x000000FF) << 24))\n";
+   out << "#define bswap16(v) (packUnorm4x8(unpackUnorm4x8(v).yxwz))\n";
+   out << "#define bswap32(v) (packUnorm4x8(unpackUnorm4x8(v).wzyx))\n";
    out << "#define signext2(v) ((v ^ 0x2) - 0x2)\n";
    out << "#define signext8(v) ((v ^ 0x80) - 0x80)\n";
    out << "#define signext10(v) ((v ^ 0x200) - 0x200)\n";


### PR DESCRIPTION
Cuts down the number of NVIDIA shader instructions per bswap32 from 11 to 2 (unpack and swizzle+pack), though I have no idea what the actual performance of those instructions is -- perhaps Nsight could give some, uh... (cough) insight into that...

We could potentially use unpack instructions to directly read some formats like 8_8_8_8 NORM, but that's a bit more involved so holding off on it for now.