### PR TITLE
opengl: Use DCInvalidateRange() as a signal to download data buffers.

### DIFF
--- a/src/libdecaf/decaf_graphics.h
+++ b/src/libdecaf/decaf_graphics.h
@@ -16,8 +16,12 @@ public:
    virtual void stop() = 0;
    virtual float getAverageFPS() = 0;
 
-   virtual void notifyCpuFlush(void *ptr, uint32_t size) = 0;  // May be called from any thread!
-   virtual void notifyGpuFlush(void *ptr, uint32_t size) = 0;  // May be called from any thread!
+   // Called for stores to emulated physical RAM, such as via DCFlushRange().
+   //  May be called from any CPU core!
+   virtual void notifyCpuFlush(void *ptr, uint32_t size) = 0;
+   // Called when the emulated CPU is about to read from emulated physical RAM,
+   //  such as after DCInvalidateRange().  May be called from any CPU core!
+   virtual void notifyGpuFlush(void *ptr, uint32_t size) = 0;
 };
 
 class OpenGLDriver : public GraphicsDriver

--- a/src/libdecaf/decaf_nullgraphicsdriver.h
+++ b/src/libdecaf/decaf_nullgraphicsdriver.h
@@ -12,8 +12,8 @@ public:
    virtual void run() override;
    virtual void stop() override;
    virtual float getAverageFPS() override;
-   virtual void notifyCpuFlush(void *addr, uint32_t size) override;
-   virtual void notifyGpuFlush(void *addr, uint32_t size) override;
+   virtual void notifyCpuFlush(void *ptr, uint32_t size) override;
+   virtual void notifyGpuFlush(void *ptr, uint32_t size) override;
 
 private:
    bool mRunning = false;

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "common/platform.h"
 #include "common/log.h"
+#include "common/platform.h"
 #include "glsl2_translate.h"
 #include "gpu/pm4.h"
 #include "gpu/latte_constants.h"
@@ -12,6 +12,7 @@
 #include <exception>
 #include <glbinding/gl/gl.h>
 #include <gsl.h>
+#include <list>
 #include <map>
 #include <mutex>
 #include <queue>
@@ -276,6 +277,16 @@ struct GLStateCache
    gl::GLuint primRestartIndex;
 };
 
+struct RemoteThreadTask
+{
+   std::function<void()> func;
+   std::condition_variable completionCV;
+
+   RemoteThreadTask(std::function<void()> func) : func(func)
+   {
+   }
+};
+
 using GLContext = uint64_t;
 
 class GLDriver : public decaf::OpenGLDriver
@@ -441,6 +452,9 @@ private:
 
    void runCommandBuffer(uint32_t *buffer, uint32_t size);
 
+   void runOnGLThread(std::function<void()> func);
+   void runRemoteThreadTasks();
+
    template<typename Type>
    Type getRegister(uint32_t id)
    {
@@ -526,6 +540,9 @@ private:
    using duration_ms = std::chrono::duration<double, std::chrono::milliseconds::period>;
    std::chrono::time_point<std::chrono::system_clock> mLastSwap;
    duration_system_clock mAverageFrameTime;
+
+   std::mutex mTaskListMutex;  // Protects mTaskList
+   std::list<RemoteThreadTask> mTaskList;
 
 #ifdef PLATFORM_WINDOWS
    uint64_t mDeviceContext = 0;

--- a/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_pm4.cpp
@@ -34,6 +34,8 @@ GLDriver::runCommandBuffer(uint32_t *buffer, uint32_t buffer_size)
          break;
       }
 
+      runRemoteThreadTasks();
+
       switch (header.type()) {
       case pm4::Header::Type3:
       {

--- a/src/libdecaf/src/modules/coreinit/coreinit_cache.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_cache.cpp
@@ -14,6 +14,9 @@ void
 DCInvalidateRange(void *addr, uint32_t size)
 {
    // TODO: DCInvalidateRange
+
+   // Also signal the GPU to update the memory range.
+   gpu::notifyGpuFlush(addr, size);
 }
 
 

--- a/src/libdecaf/src/modules/coreinit/coreinit_lockedcache.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_lockedcache.cpp
@@ -153,6 +153,10 @@ LCLoadDMABlocks(void *dst,
                 const void *src,
                 uint32_t size)
 {
+   // Signal the GPU to update the source range if necessary, as with
+   //  DCInvalidateRange().
+   gpu::notifyGpuFlush(const_cast<void *>(src), size);
+
    if (size == 0) {
       size = 128;
    }


### PR DESCRIPTION
This is the counterpart to the DCFlush change. For this, we do need to synchronize with the GPU thread (the data has to actually be available to the CPU when the DCInvalidate handler returns), so I've added back a simplified version of Brett's task code. I ended up using the same dummy buffer method to pump the PM4 loop if necessary; it would be cleaner to have a shared wakeup signal, but that's more involved and requires changes to the queue handling as well, so I think this is good enough for now.