### PR TITLE
opengl: Don't reject depth+stencil buffers in 24_8 format.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_depthbuffer.cpp
@@ -36,8 +36,10 @@ bool GLDriver::checkActiveDepthBuffer()
    gl::GLuint surfaceObject = surface ? surface->active->object : 0;
 
    if (format != latte::DEPTH_8_24
-      && format != latte::DEPTH_8_24_FLOAT
-      && format != latte::DEPTH_X24_8_32_FLOAT) {
+    && format != latte::DEPTH_8_24_FLOAT
+    && format != latte::DEPTH_24_8
+    && format != latte::DEPTH_24_8_FLOAT
+    && format != latte::DEPTH_X24_8_32_FLOAT) {
       // You cannot bind a stencil buffer if the framebuffer does not support it.
       stencil_enable = false;
    }


### PR DESCRIPTION
This might fix #330.