### PR TITLE
coreinit: Fix uint8_t overflow.

### DIFF
--- a/src/libdecaf/src/modules/coreinit/coreinit_device.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_device.cpp
@@ -61,9 +61,9 @@ OSReadRegister32Ex(OSDeviceID device,
             vpad::VPADStatus status;
 
             if (vpad::VPADRead(0, &status, 1, nullptr) == 1) {
-               // VPAD sticks are -1.0f to 1.0f, whereas these sticks are 0 - 256
+               // VPAD sticks are -1.0f to 1.0f, whereas these sticks are 0 - 255
                auto convertStickValue = [](float value) {
-                  return static_cast<uint8_t>(((value + 1.0f) / 2.0f) * 256.0f);
+                  return static_cast<uint8_t>(std::min(static_cast<unsigned int>(((value + 1.0f) / 2.0f) * 256.0f), 255u));
                };
 
                status0 = status0


### PR DESCRIPTION
Written so 0.0 translates to 128 instead of a potentially unstable value between 127 and 128, though I don't know if that's what hardware does.