### PR TITLE
opengl: Use a sorted resource map to optimize resource updates.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_resource.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_resource.cpp
@@ -1,0 +1,65 @@
+#ifndef DECAF_NOGL
+
+#include "common/decaf_assert.h"
+#include "opengl_resource.h"
+
+namespace gpu
+{
+
+namespace opengl
+{
+
+ResourceMemoryMap::ResourceMemoryMap()
+   : mCounter(0)
+{
+}
+
+void
+ResourceMemoryMap::addResource(Resource *resource)
+{
+   std::unique_lock<std::mutex> lock(mMutex);
+
+   if (mKnownResources.find(resource) != mKnownResources.end()) {
+      return;
+   }
+
+   // mCounter serves to differentiate multiple resources with the same
+   //  start or end address.
+   auto counter = mCounter++;
+   auto keyStart = static_cast<uint64_t>(resource->cpuMemStart) << 32 | counter;
+   auto keyEnd = static_cast<uint64_t>(resource->cpuMemEnd - 1) << 32 | counter;
+   mKnownResources[resource] = counter;
+
+   // We insert entries for both the start (first byte) and end (last byte)
+   //  of the resource.  Then in markDirty(), we can simply set the dirty
+   //  flag on every resource with at least one key (region endpoint) in
+   //  the dirty region.
+   decaf_check(mMemoryMap.find(keyStart) == mMemoryMap.end());
+   mMemoryMap[keyStart] = resource;
+   decaf_check(mMemoryMap.find(keyEnd) == mMemoryMap.end());
+   mMemoryMap[keyEnd] = resource;
+}
+
+void
+ResourceMemoryMap::removeResource(Resource *resource)
+{
+   std::unique_lock<std::mutex> lock(mMutex);
+
+   auto knownIter = mKnownResources.find(resource);
+   decaf_check(knownIter != mKnownResources.end());
+   auto counter = knownIter->second;
+   mKnownResources.erase(knownIter);
+   auto keyStart = static_cast<uint64_t>(resource->cpuMemStart) << 32 | counter;
+   auto keyEnd = static_cast<uint64_t>(resource->cpuMemEnd - 1) << 32 | counter;
+
+   decaf_check(mMemoryMap.find(keyStart) != mMemoryMap.end());
+   mMemoryMap.erase(keyStart);
+   decaf_check(mMemoryMap.find(keyEnd) != mMemoryMap.end());
+   mMemoryMap.erase(keyEnd);
+}
+
+} // namespace opengl
+
+} // namespace gpu
+
+#endif // DECAF_NOGL

--- a/src/libdecaf/src/gpu/opengl/opengl_resource.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_resource.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#ifndef DECAF_NOGL
+
+#include <map>
+#include <mutex>
+#include <unordered_map>
+
+namespace gpu
+{
+
+namespace opengl
+{
+
+struct Resource
+{
+   //! The start of the CPU memory region this occupies
+   uint32_t cpuMemStart;
+
+   //! The end of the CPU memory region this occupies (plus 1)
+   uint32_t cpuMemEnd;
+
+   //! Hash of the memory contents, for detecting changes
+   uint64_t cpuMemHash[2] = { 0, 0 };
+
+   //! True if a DCFlush has been received for the memory region
+   bool dirtyMemory = true;
+
+   //! The type of resource (poor man's RTTI for surfaceSync())
+   enum Type {
+      DATA_BUFFER,
+      SHADER,
+      SURFACE,
+   } type;
+
+   Resource(Type type_) : type(type_) { }
+};
+
+// Manages data ranges associated with resources for efficient querying by
+//  address.  addResource() and removeResource() lock the object for the
+//  duration of the call.
+class ResourceMemoryMap
+{
+public:
+
+   class Iterator
+   {
+   public:
+      Iterator(const ResourceMemoryMap &map, uint32_t start, uint32_t size)
+         : mMap(map),
+           mKeyStart(static_cast<uint64_t>(start) << 32),
+           mKeyEnd(static_cast<uint64_t>(start + size) << 32),
+           mMapIter(mMap.mMemoryMap.lower_bound(mKeyStart))
+      {
+      }
+
+      Resource *next()
+      {
+         if (mMapIter != mMap.mMemoryMap.end() && mMapIter->first < mKeyEnd) {
+            return (mMapIter++)->second;
+         } else {
+            return nullptr;
+         }
+      }
+
+   private:
+      const ResourceMemoryMap &mMap;
+      uint64_t mKeyStart;
+      uint64_t mKeyEnd;
+      std::map<uint64_t, Resource *>::const_iterator mMapIter;
+   };
+
+   ResourceMemoryMap();
+
+   void
+   addResource(Resource *resource);
+
+   void
+   removeResource(Resource *resource);
+
+   std::mutex &
+   getMutex()
+   {
+      return mMutex;
+   }
+
+   Iterator
+   getIterator(uint32_t start, uint32_t size)
+   {
+      return Iterator(*this, start, size);
+   }
+
+private:
+   std::mutex mMutex;
+   std::unordered_map<Resource *, uint32_t> mKnownResources;
+   std::map<uint64_t, Resource *> mMemoryMap;
+   uint32_t mCounter;
+};
+
+} // namespace opengl
+
+} // namespace gpu
+
+#endif // DECAF_NOGL


### PR DESCRIPTION
Since resources are not currently expunged when the memory is reused for another purpose, the resource maps grow over time, causing the linear scans in notify{Cpu,Gpu}Flush() and surfaceSync() to consume more and more CPU as time goes on.  This change introduces a ResourceMemoryMap class to keep a sorted list of resource memory endpoints, so the scans can touch exactly those resources that fit the requested memory range without having to iterate over every single allocated resource.

This gives me around a 3x speedup in Xenoblade after the intro scene.