### PR TITLE
Reimplement GPU synchronization.

### DIFF
--- a/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.cpp
@@ -409,6 +409,26 @@ GLDriver::getGpuClock()
    return coreinit::OSGetTime();
 }
 
+static uint64_t
+swapValueForWrite(uint64_t value, latte::CB_ENDIAN swap)
+{
+   switch (swap)
+   {
+   case latte::CB_ENDIAN::NONE:
+      break;
+   case latte::CB_ENDIAN::SWAP_8IN64:
+      value = byte_swap(value);
+      break;
+   case latte::CB_ENDIAN::SWAP_8IN32:
+      value = byte_swap(static_cast<uint32_t>(value));
+      break;
+   case latte::CB_ENDIAN::SWAP_8IN16:
+      decaf_abort(fmt::format("Unexpected MEM_WRITE/EVENT_WRITE endian swap {}", swap));
+   }
+
+   return value;
+}
+
 void
 GLDriver::memWrite(const pm4::MemWrite &data)
 {
@@ -421,19 +441,7 @@ GLDriver::memWrite(const pm4::MemWrite &data)
       value = static_cast<uint64_t>(data.dataLo) | static_cast<uint64_t>(data.dataHi) << 32;
    }
 
-   switch (data.addrLo.ENDIAN_SWAP())
-   {
-   case latte::CB_ENDIAN::NONE:
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN64:
-      value = byte_swap(value);
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN32:
-      value = byte_swap(static_cast<uint32_t>(value));
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN16:
-      decaf_abort(fmt::format("Unexpected MEM_WRITE endian swap {}", data.addrLo.ENDIAN_SWAP()));
-   }
+   value = swapValueForWrite(value, data.addrLo.ENDIAN_SWAP());
 
    if (data.addrHi.DATA32()) {
       *reinterpret_cast<uint32_t *>(addr) = static_cast<uint32_t>(value);
@@ -462,7 +470,14 @@ GLDriver::eventWrite(const pm4::EventWrite &data)
 
          decaf_check(mOccQuery);
          gl::glEndQuery(gl::GL_SAMPLES_PASSED);
-         gl::glGetQueryObjectui64v(mOccQuery, gl::GL_QUERY_RESULT, &value);
+
+         // Perform the write when it completes instead of blocking here.
+         addQuerySync(mOccQuery, [=](){
+            uint64_t result;
+            gl::glGetQueryObjectui64v(mOccQuery, gl::GL_QUERY_RESULT, &result);
+            result = swapValueForWrite(result, data.addrLo.ENDIAN_SWAP());
+            *reinterpret_cast<uint64_t *>(ptr) = result;
+         });
       } else {
          if (mLastOccQueryAddress) {
             gLog->warn("Program started a new occlusion query (at 0x{:X}) while one was already in progress (at 0x{:X})", mLastOccQueryAddress, addr);
@@ -473,6 +488,16 @@ GLDriver::eventWrite(const pm4::EventWrite &data)
          if (!mOccQuery) {
             gl::glGenQueries(1, &mOccQuery);
             decaf_check(mOccQuery);
+         } else {
+            // Ensure that any pending query has been written so we don't
+            //  clobber the result.
+            gl::GLint isReady;
+            while (isReady = static_cast<gl::GLint>(gl::GL_TRUE),
+                   gl::glGetQueryObjectiv(mOccQuery, gl::GL_QUERY_RESULT_AVAILABLE, &isReady),
+                   !isReady) {
+               std::this_thread::sleep_for(std::chrono::microseconds(10));
+            }
+            checkSyncObjects(0);
          }
 
          gl::glBeginQuery(gl::GL_SAMPLES_PASSED, mOccQuery);
@@ -482,18 +507,7 @@ GLDriver::eventWrite(const pm4::EventWrite &data)
       decaf_abort(fmt::format("Unexpected event type {}", type));
    }
 
-   switch (data.addrLo.ENDIAN_SWAP()) {
-   case latte::CB_ENDIAN::NONE:
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN64:
-      value = byte_swap(value);
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN32:
-      value = byte_swap(static_cast<uint32_t>(value));
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN16:
-      decaf_abort("Unexpected EVENT_WRITE endian swap 8IN16");
-   }
+   value = swapValueForWrite(value, data.addrLo.ENDIAN_SWAP());
 
    *reinterpret_cast<uint64_t *>(ptr) = value;
 }
@@ -519,18 +533,7 @@ GLDriver::eventWriteEOP(const pm4::EventWriteEOP &data)
       decaf_abort(fmt::format("Unexpected EOP event type {}", data.eventInitiator.EVENT_TYPE()));
    }
 
-   switch (data.addrLo.ENDIAN_SWAP()) {
-   case latte::CB_ENDIAN::NONE:
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN64:
-      value = byte_swap(value);
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN32:
-      value = byte_swap(static_cast<uint32_t>(value));
-      break;
-   case latte::CB_ENDIAN::SWAP_8IN16:
-      decaf_abort("Unexpected EVENT_WRITE_EOP endian swap 8IN16");
-   }
+   value = swapValueForWrite(value, data.addrLo.ENDIAN_SWAP());
 
    switch (data.addrHi.DATA_SEL()) {
    case pm4::EWP_DATA_DISCARD:
@@ -574,6 +577,12 @@ GLDriver::addFenceSync(std::function<void()> func)
 }
 
 void
+GLDriver::addQuerySync(gl::GLuint query, std::function<void()> func)
+{
+   mSyncList.emplace_back(query, func);
+}
+
+void
 GLDriver::checkSyncObjects(gl::GLuint64 timeout)
 {
    if (mSyncList.empty()) {
@@ -583,26 +592,53 @@ GLDriver::checkSyncObjects(gl::GLuint64 timeout)
    // Ensure that all sync commands have been sent to the server.
    gl::glFlush();
 
-   bool anySignaled = false;
+   bool anyComplete = false;
 
    // Iterate over the list from newest to oldest, so we never call a
    //  fence function without also calling all previous fence functions
    //  (as could happen if syncs complete while we're iterating forwards).
    for (auto i = mSyncList.rbegin(); i != mSyncList.rend(); ++i) {
-      if (&*i == &mSyncList.front() && !anySignaled && timeout > 0) {
-         auto result = gl::glClientWaitSync(i->sync, static_cast<gl::SyncObjectMask>(0), timeout);
-         i->isSignaled = (result != gl::GL_TIMEOUT_EXPIRED);
+      if (&*i == &mSyncList.front() && !anyComplete && timeout > 0) {
+         switch (i->type) {
+         case SyncObject::FENCE:
+            gl::GLenum result;
+            result = gl::glClientWaitSync(i->sync, static_cast<gl::SyncObjectMask>(0), timeout);
+            i->isComplete = (result != gl::GL_TIMEOUT_EXPIRED);
+            break;
+         case SyncObject::QUERY: {
+            gl::GLint isReady = static_cast<gl::GLint>(gl::GL_TRUE);
+            gl::glGetQueryObjectiv(mOccQuery, gl::GL_QUERY_RESULT_AVAILABLE, &isReady);
+            if (isReady) {
+               i->isComplete = true;
+            } else {
+               std::this_thread::sleep_for(std::chrono::nanoseconds(timeout));
+            }
+            break;
+         }
+         }
       } else {
-         gl::GLint syncState = static_cast<gl::GLint>(gl::GL_SIGNALED);  // avoid hanging on error
-         gl::glGetSynciv(i->sync, gl::GL_SYNC_STATUS, sizeof(syncState), nullptr, &syncState);
-         i->isSignaled = (syncState == gl::GL_SIGNALED);
+         switch (i->type) {
+         case SyncObject::FENCE: {
+            gl::GLint syncState;
+            syncState = static_cast<gl::GLint>(gl::GL_SIGNALED);  // avoid hanging on error
+            gl::glGetSynciv(i->sync, gl::GL_SYNC_STATUS, sizeof(syncState), nullptr, &syncState);
+            i->isComplete = (syncState == gl::GL_SIGNALED);
+            break;
+         }
+         case SyncObject::QUERY: {
+            gl::GLint isReady = static_cast<int>(gl::GL_TRUE);
+            gl::glGetQueryObjectiv(mOccQuery, gl::GL_QUERY_RESULT_AVAILABLE, &isReady);
+            i->isComplete = !!isReady;
+            break;
+         }
+         }
       }
-      anySignaled |= i->isSignaled;
+      anyComplete |= i->isComplete;
    }
 
    // Now finalize and remove all signaled syncs from oldest to newest.
    for (auto i = mSyncList.begin(); i != mSyncList.end(); ) {
-      if (i->isSignaled) {
+      if (i->isComplete) {
          i->func();
          i = mSyncList.erase(i);
       } else {

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -272,11 +272,23 @@ struct RemoteThreadTask
 
 struct SyncObject
 {
-   gl::GLsync sync;
-   bool isSignaled;
+   enum Type {
+      FENCE,
+      QUERY,
+   } type;
+
+   union {
+      gl::GLsync sync;
+      gl::GLuint query;
+   };
+   bool isComplete;
    std::function<void()> func;
 
-   SyncObject(gl::GLsync sync_, std::function<void()> func_) : sync(sync_), func(func_)
+   SyncObject(gl::GLsync sync_, std::function<void()> func_) : type(FENCE), sync(sync_), func(func_)
+   {
+   }
+
+   SyncObject(gl::GLuint query_, std::function<void()> func_) : type(QUERY), query(query_), func(func_)
    {
    }
 };
@@ -453,6 +465,9 @@ private:
 
    void
    addFenceSync(std::function<void()> func);
+
+   void
+   addQuerySync(gl::GLuint query, std::function<void()> func);
 
    void
    checkSyncObjects(gl::GLuint64 timeout);

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -270,6 +270,17 @@ struct RemoteThreadTask
    }
 };
 
+struct SyncObject
+{
+   gl::GLsync sync;
+   bool isSignaled;
+   std::function<void()> func;
+
+   SyncObject(gl::GLsync sync_, std::function<void()> func_) : sync(sync_), func(func_)
+   {
+   }
+};
+
 using GLContext = uint64_t;
 
 class GLDriver : public decaf::OpenGLDriver, public Pm4Processor
@@ -438,6 +449,12 @@ private:
                       size_t size);
 
    void
+   addFenceSync(std::function<void()> func);
+
+   void
+   checkSyncObjects(gl::GLuint64 timeout);
+
+   void
    runOnGLThread(std::function<void()> func);
 
    void
@@ -521,6 +538,7 @@ private:
    std::mutex mTaskListMutex;  // Protects mTaskList
    std::list<RemoteThreadTask> mTaskList;
 
+   std::list<SyncObject> mSyncList;
 };
 
 } // namespace opengl

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -23,7 +23,6 @@
 #include <list>
 #include <map>
 #include <mutex>
-#include <queue>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -185,22 +184,6 @@ struct FeedbackBufferState
    gl::GLuint object;
    uint32_t baseOffset;
    uint32_t currentOffset;
-};
-
-enum class SyncWaitType : uint32_t
-{
-   Fence,
-   Query
-};
-
-struct SyncWait
-{
-   SyncWaitType type;
-   union {
-      gl::GLsync fence;
-      gl::GLuint query;
-   };
-   std::function<void()> func;
 };
 
 struct ColorBufferCache
@@ -455,12 +438,6 @@ private:
                       size_t size);
 
    void
-   injectFence(std::function<void()> func);
-
-   void
-   checkSyncObjects();
-
-   void
    runOnGLThread(std::function<void()> func);
 
    void
@@ -516,15 +493,13 @@ private:
    ScanBufferChain mTvScanBuffers;
    ScanBufferChain mDrcScanBuffers;
 
-   std::queue<SyncWait> mSyncWaits;
-
    gl::GLuint mFeedbackQuery = 0;
    bool mFeedbackActive = false;
    gl::GLenum mFeedbackPrimitive;
    std::array<FeedbackBufferState, latte::MaxStreamOutBuffers> mFeedbackBufferState;
 
    gl::GLuint mOccQuery = 0;
-   uint64_t mTotalSamplesPassed = 0;
+   uint32_t mLastOccQueryAddress = 0;
 
    GLStateCache mGLStateCache;
    bool mFramebufferChanged = false;

--- a/src/libdecaf/src/gpu/opengl/opengl_driver.h
+++ b/src/libdecaf/src/gpu/opengl/opengl_driver.h
@@ -426,6 +426,9 @@ private:
    void
    endTransformFeedback();
 
+   void
+   updateTransformFeedbackOffsets();
+
    int
    countModifiedUniforms(latte::Register firstReg,
                          uint32_t lastUniformUpdate);
@@ -511,6 +514,8 @@ private:
    ScanBufferChain mDrcScanBuffers;
 
    gl::GLuint mFeedbackQuery = 0;
+   unsigned int mFeedbackQueryBuffers = 0;
+   std::array<unsigned int, latte::MaxStreamOutBuffers> mFeedbackQueryStride;
    bool mFeedbackActive = false;
    gl::GLenum mFeedbackPrimitive;
    std::array<FeedbackBufferState, latte::MaxStreamOutBuffers> mFeedbackBufferState;


### PR DESCRIPTION
The previous implementation had huge overhead (I measured a frame rate drop of close to 50% in Xenoblade) and wrapped several operations which arguably don't need wrapping, such as simple data writes.