### PR TITLE
sdl: Make audio frame length configurable

### DIFF
--- a/src/decaf-sdl/config.cpp
+++ b/src/decaf-sdl/config.cpp
@@ -74,6 +74,13 @@ controllerTypeFromString(const std::string &typeStr)
 
 } // namespace input
 
+namespace sound
+{
+
+unsigned frame_length = 30;
+
+} // namespace sound
+
 namespace log
 {
 
@@ -188,8 +195,10 @@ struct CerealSound
    template <class Archive>
    void serialize(Archive &ar)
    {
-      using namespace decaf::config::sound;
-      ar(CEREAL_NVP(dump_sounds));
+      using namespace ::decaf::config::sound;
+      using namespace sound;
+      ar(CEREAL_NVP(dump_sounds),
+         CEREAL_NVP(frame_length));
    }
 };
 

--- a/src/decaf-sdl/config.h
+++ b/src/decaf-sdl/config.h
@@ -246,6 +246,14 @@ extern std::string name;
 
 } // namespace input
 
+namespace sound {
+
+// Frame length factor for audio data.
+// Default is 30 (x 48 = 1440 for 48kHz)
+extern unsigned frame_length;
+
+} // namespace sound
+
 void
 initialize();
 

--- a/src/decaf-sdl/decafsdl_sound.cpp
+++ b/src/decaf-sdl/decafsdl_sound.cpp
@@ -1,5 +1,6 @@
 #include "clilog.h"
 #include <common/decaf_assert.h>
+#include "config.h"
 #include "decafsdl.h"
 #include <SDL.h>
 
@@ -9,7 +10,7 @@ DecafSDLSound::start(unsigned outputRate,
 {
    mNumChannelsIn = numChannels;
    mNumChannelsOut = std::min(numChannels, 2u);  // TODO: support surround output
-   mOutputFrameLen = 1024;  // TODO: make this configurable (latency control)
+   mOutputFrameLen = config::sound::frame_length * (outputRate / 1000);
 
    // Set up the ring buffer with enough space for 3 output frames of audio
    mOutputBuffer.resize(mOutputFrameLen * mNumChannelsOut * 3);


### PR DESCRIPTION
And make it depend on audio output rate.
Default value is 30 so with a 48kHz sample rate, the actual frame length becomes 30x48 = 1440 bytes.
Also change the default which used to be 1024, which on my system was too low and produced flickering sound.