### PR TITLE
decaf-sdl: Fix crash when the system changes the audio frame size.

### DIFF
--- a/src/decaf-sdl/decafsdl_sound.cpp
+++ b/src/decaf-sdl/decafsdl_sound.cpp
@@ -12,11 +12,6 @@ DecafSDLSound::start(unsigned outputRate,
    mNumChannelsOut = std::min(numChannels, 2u);  // TODO: support surround output
    mOutputFrameLen = config::sound::frame_length * (outputRate / 1000);
 
-   // Set up the ring buffer with enough space for 3 output frames of audio
-   mOutputBuffer.resize(mOutputFrameLen * mNumChannelsOut * 3);
-   mBufferWritePos = 0;
-   mBufferReadPos = 0;
-
    SDL_AudioSpec audiospec;
    audiospec.format = AUDIO_S16LSB;
    audiospec.freq = outputRate;
@@ -25,10 +20,31 @@ DecafSDLSound::start(unsigned outputRate,
    audiospec.callback = sdlCallback;
    audiospec.userdata = this;
 
-   if (SDL_OpenAudio(&audiospec, nullptr) != 0) {
+   SDL_AudioSpec actualspec;
+   if (SDL_OpenAudio(&audiospec, &actualspec) != 0) {
       gCliLog->error("Failed to open audio device: {}", SDL_GetError());
       return false;
    }
+   if (actualspec.format != audiospec.format) {
+      gCliLog->error("SDL_OpenAudio() returned wrong format {}", actualspec.format);
+      return false;
+   }
+   if (actualspec.freq != outputRate) {
+      gCliLog->error("Failed to open audio device at {} Hz (got {} instead)", outputRate, actualspec.freq);
+      return false;
+   }
+   if (actualspec.channels != mNumChannelsOut) {
+      gCliLog->error("Failed to open audio device for {} channels (got {} instead)", mNumChannelsOut, actualspec.channels);
+      return false;
+   }
+   if (actualspec.samples != mOutputFrameLen) {
+      gCliLog->warn("Requested frame size of {} samples but got {} instead", mOutputFrameLen, actualspec.samples);
+   }
+
+   // Set up the ring buffer with enough space for 3 output frames of audio
+   mOutputBuffer.resize(actualspec.samples * mNumChannelsOut * 3);
+   mBufferWritePos = 0;
+   mBufferReadPos = 0;
 
    SDL_PauseAudio(0);
    return true;


### PR DESCRIPTION
If the actual output frame size is different from the requested size, the audio callback would overrun the read buffer and crash with an assertion failure. Regression introduced in 2625308, which made the frame size not be a power of two (Linux requires a power-of-two size).

Also sanity-check the other audio parameters returned by SDL_OpenAudio.