### PR TITLE
jit: Inline code block lookups in the execution loop.

### DIFF
--- a/src/libcpu/src/jit/binrec/jit_binrec.h
+++ b/src/libcpu/src/jit/binrec/jit_binrec.h
@@ -96,6 +96,9 @@ public:
 protected:
    BinrecHandle *createBinrecHandle();
 
+   inline CodeBlock *
+   getCodeBlockFast(BinrecCore *core, uint32_t address);
+
    CodeBlock *
    checkForCodeBlockTrampoline(uint32_t address);
 

--- a/src/libcpu/src/jit/jit_codecache.cpp
+++ b/src/libcpu/src/jit/jit_codecache.cpp
@@ -231,17 +231,6 @@ CodeCache::getBlockByAddress(uint32_t address)
 
 
 /**
- * Find a compiled code block from it's CodeBlockIndex.
- */
-CodeBlock *
-CodeCache::getBlockByIndex(CodeBlockIndex index)
-{
-   auto blockAddress = mDataAllocator.baseAddress + index * sizeof(CodeBlock);
-   return reinterpret_cast<CodeBlock *>(blockAddress);
-}
-
-
-/**
  * Find a compiled code block's CodeBlockIndex.
  */
 CodeBlockIndex


### PR DESCRIPTION
This reduces overall CPU usage by around 2% in my tests.