### PR TITLE
Only enable the glbinding command callback when debugging.

### DIFF
--- a/src/decaf-sdl/decafsdl_opengl.cpp
+++ b/src/decaf-sdl/decafsdl_opengl.cpp
@@ -128,31 +128,32 @@ void
 DecafSDLOpenGL::initialiseContext()
 {
    glbinding::Binding::initialize();
-   glbinding::setCallbackMaskExcept(glbinding::CallbackMask::After | glbinding::CallbackMask::ParametersAndReturnValue, { "glGetError" });
-   glbinding::setAfterCallback([](const glbinding::FunctionCall &call) {
-      auto error = glbinding::Binding::GetError.directCall();
-
-      if (error != gl::GL_NO_ERROR) {
-         fmt::MemoryWriter writer;
-         writer << call.function->name() << "(";
-
-         for (unsigned i = 0; i < call.parameters.size(); ++i) {
-            writer << call.parameters[i]->asString();
-            if (i < call.parameters.size() - 1)
-               writer << ", ";
-         }
-
-         writer << ")";
-
-         if (call.returnValue) {
-            writer << " -> " << call.returnValue->asString();
-         }
-
-         gCliLog->error("OpenGL error: {} with {}", glbinding::Meta::getString(error), writer.str());
-      }
-   });
 
    if (decaf::config::gpu::debug) {
+      glbinding::setCallbackMaskExcept(glbinding::CallbackMask::After | glbinding::CallbackMask::ParametersAndReturnValue, { "glGetError" });
+      glbinding::setAfterCallback([](const glbinding::FunctionCall &call) {
+         auto error = glbinding::Binding::GetError.directCall();
+
+         if (error != gl::GL_NO_ERROR) {
+            fmt::MemoryWriter writer;
+            writer << call.function->name() << "(";
+
+            for (unsigned i = 0; i < call.parameters.size(); ++i) {
+               writer << call.parameters[i]->asString();
+               if (i < call.parameters.size() - 1)
+                  writer << ", ";
+            }
+
+            writer << ")";
+
+            if (call.returnValue) {
+               writer << " -> " << call.returnValue->asString();
+            }
+
+            gCliLog->error("OpenGL error: {} with {}", glbinding::Meta::getString(error), writer.str());
+         }
+      });
+
       gl::glDebugMessageCallback(&debugMessageCallback, nullptr);
       gl::glEnable(gl::GL_DEBUG_OUTPUT);
       gl::glEnable(gl::GL_DEBUG_OUTPUT_SYNCHRONOUS);

--- a/tools/pm4-replay/sdl_window_draw.cpp
+++ b/tools/pm4-replay/sdl_window_draw.cpp
@@ -102,31 +102,32 @@ void
 SDLWindow::initialiseContext()
 {
    glbinding::Binding::initialize();
-   glbinding::setCallbackMaskExcept(glbinding::CallbackMask::After | glbinding::CallbackMask::ParametersAndReturnValue, { "glGetError" });
-   glbinding::setAfterCallback([](const glbinding::FunctionCall &call) {
-      auto error = glbinding::Binding::GetError.directCall();
-
-      if (error != gl::GL_NO_ERROR) {
-         fmt::MemoryWriter writer;
-         writer << call.function->name() << "(";
-
-         for (unsigned i = 0; i < call.parameters.size(); ++i) {
-            writer << call.parameters[i]->asString();
-            if (i < call.parameters.size() - 1)
-               writer << ", ";
-         }
-
-         writer << ")";
-
-         if (call.returnValue) {
-            writer << " -> " << call.returnValue->asString();
-         }
-
-         gLog->error("OpenGL error: {} with {}", glbinding::Meta::getString(error), writer.str());
-      }
-   });
 
    if (decaf::config::gpu::debug) {
+      glbinding::setCallbackMaskExcept(glbinding::CallbackMask::After | glbinding::CallbackMask::ParametersAndReturnValue, { "glGetError" });
+      glbinding::setAfterCallback([](const glbinding::FunctionCall &call) {
+         auto error = glbinding::Binding::GetError.directCall();
+
+         if (error != gl::GL_NO_ERROR) {
+            fmt::MemoryWriter writer;
+            writer << call.function->name() << "(";
+
+            for (unsigned i = 0; i < call.parameters.size(); ++i) {
+               writer << call.parameters[i]->asString();
+               if (i < call.parameters.size() - 1)
+                  writer << ", ";
+            }
+
+            writer << ")";
+
+            if (call.returnValue) {
+               writer << " -> " << call.returnValue->asString();
+            }
+
+            gLog->error("OpenGL error: {} with {}", glbinding::Meta::getString(error), writer.str());
+         }
+      });
+
       gl::glDebugMessageCallback(&debugMessageCallback, nullptr);
       gl::glEnable(gl::GL_DEBUG_OUTPUT);
       gl::glEnable(gl::GL_DEBUG_OUTPUT_SYNCHRONOUS);


### PR DESCRIPTION
Enabling the callback introduces significant overhead; I've observed slowdown of up to 35% in GPU-bound code, with the GPU thread spending over 15% of its time just in malloc() and free() calls from glbinding.