### PR TITLE
swkbd: Fix GetInputFormString() returning wrong byte order under GCC.

### DIFF
--- a/src/libdecaf/src/modules/swkbd/swkbd_core.cpp
+++ b/src/libdecaf/src/modules/swkbd/swkbd_core.cpp
@@ -125,7 +125,7 @@ GetDrawStringInfo(DrawStringInfo *info)
 const be_val<uint16_t> *
 GetInputFormString()
 {
-   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
    auto wide = converter.from_bytes(sInputBuffer);
    auto result = reinterpret_cast<be_val<uint16_t> *>(sWorkMemory);
 


### PR DESCRIPTION
I can't find an explicit reference in the C++11 spec, but it appears that the encoding of wchar_t is implementation-defined (such that ```(int)L'a' == 'a'``` doesn't necessarily hold), while char16_t is simply "a 16-bit-wide char". At any rate, the cppreference.com example for UTF8-to-UTF16 conversion uses char16_t, so hopefully this formulation should be safe everywhere.