### PR TITLE
Fix munmap of incorrect address.

### DIFF
--- a/src/common/src/platform_posix_memory.cpp
+++ b/src/common/src/platform_posix_memory.cpp
@@ -35,7 +35,7 @@ reserveMemory(size_t address, size_t size)
 
    if (result != baseAddress) {
       if (result != nullptr) {
-         freeMemory(address, size);
+         munmap(result, size);
       }
 
       return false;


### PR DESCRIPTION
The previous code checked if the mapped address (result) matches the desired address (baseAddress). If it does not match, the previous code attempted to unmap the desired address rather than the mapped address.

This fix unmaps the mapped address.