### PR TITLE
Add a configuration option to set the path to the resources directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are two decaf targets:
 
 `./decaf-sdl play <path to game>`
 
-It is recommend to run the emulator from the root git directory so that it is able to access `resources/fonts/*`
+It is recommended to run the emulator from the root git directory so that it is able to access `resources/fonts/*`.  Alternatively, set `resources_path` in the configuration file to point to the resources directory.
 
 Configuration files can be found at:
 - Windows - `%APPDATA%\decaf`

--- a/src/decaf-cli/main.cpp
+++ b/src/decaf-cli/main.cpp
@@ -79,9 +79,6 @@ getCommandLineParser()
                   allowed<std::string> { {
                      "EUR", "JAP", "US"
                   } })
-      .add_option("sys-path",
-                  description { "Where to locate any external system files." },
-                  value<std::string> {})
       .add_option("time-scale",
                   description { "Time scale factor for emulated clock." },
                   default_value<double> { 1.0 })

--- a/src/decaf-sdl/config.cpp
+++ b/src/decaf-sdl/config.cpp
@@ -217,6 +217,7 @@ struct CerealSystem
       ar(CEREAL_NVP(region),
          CEREAL_NVP(mlc_path),
          CEREAL_NVP(sdcard_path),
+         CEREAL_NVP(resources_path),
          CEREAL_NVP(lle_modules));
    }
 };

--- a/src/decaf-sdl/main.cpp
+++ b/src/decaf-sdl/main.cpp
@@ -118,11 +118,11 @@ getCommandLineParser()
                   description { "Enable sound output." })
       .add_option("dx12",
                   description { "Use DirectX 12 backend." })
-      .add_option("sys-path",
-                  description { "Where to locate any external system files." },
-                  value<std::string> {})
       .add_option("content-path",
                   description { "Sets which path to mount to /vol/content, only set for standalone rpx files." },
+                  value<std::string> {})
+      .add_option("resources-path",
+                  description { "Path to Decaf resource files." },
                   value<std::string> {})
       .add_option("time-scale",
                   description { "Time scale factor for emulated clock." },
@@ -362,6 +362,10 @@ start(excmd::parser &parser,
 
    if (options.has("content-path")) {
       decaf::config::system::content_path = options.get<std::string>("content-path");
+   }
+
+   if (options.has("resources-path")) {
+      decaf::config::system::resources_path = options.get<std::string>("resources-path");
    }
 
    if (options.has("time-scale")) {

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -118,6 +118,9 @@ extern std::string sdcard_path;
 //! Path to /vol/content for standalone .rpx applications
 extern std::string content_path;
 
+//! Path to directory containing Decaf resources
+extern std::string resources_path;
+
 //! Time scale factor for emulated clock
 extern double time_scale;
 

--- a/src/libdecaf/src/debugger/debugger_ui_manager.cpp
+++ b/src/libdecaf/src/debugger/debugger_ui_manager.cpp
@@ -120,7 +120,8 @@ void Manager::load(const std::string &configPath,
    auto config = ImFontConfig { };
    config.MergeMode = true;
    config.MergeGlyphCenterV = true;
-   io.Fonts->AddFontFromFileTTF("resources/fonts/DejaVuSansMono.ttf", 13.0f, &config, iconsRanges);
+   auto fontPath = decaf::config::system::resources_path + "/fonts/DejaVuSansMono.ttf";
+   io.Fonts->AddFontFromFileTTF(fontPath.c_str(), 13.0f, &config, iconsRanges);
 
    // Set default syle
    auto &style = ImGui::GetStyle();

--- a/src/libdecaf/src/decaf_config.cpp
+++ b/src/libdecaf/src/decaf_config.cpp
@@ -96,6 +96,7 @@ int region = static_cast<int>(coreinit::SCIRegion::USA);
 std::string mlc_path = "mlc";
 std::string sdcard_path = "sdcard";
 std::string content_path = {};
+std::string resources_path = "resources";
 double time_scale = 1.0;
 std::vector<std::string> lle_modules;
 

--- a/src/libdecaf/src/modules/coreinit/coreinit_shared.cpp
+++ b/src/libdecaf/src/modules/coreinit/coreinit_shared.cpp
@@ -88,7 +88,7 @@ loadSharedData()
 
    if (!allFound) {
       // As a backup, try load Source Sans Pro from resources folder.
-      auto file = std::ifstream { "resources/fonts/SourceSansPro-Regular.ttf",
+      auto file = std::ifstream { decaf::config::system::resources_path + "/fonts/SourceSansPro-Regular.ttf",
                                   std::ifstream::in | std::ifstream::binary };
       auto sourceSansProSize = uint32_t { 0 };
       uint8_t *sourceSansProData = nullptr;


### PR DESCRIPTION
This allows the program to be run from outside the Decaf source tree.
The path can also be set with --resources-path on the command line.

Also remove the unused "--sys-path" option from the command line
option list.