### PR TITLE
CMake: remove Mincore dependency

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -210,7 +210,7 @@ if(DECAF_SDL)
     set(SDL2_LINK sdl2_final PARENT_SCOPE)
 
     if(MSVC)
-        target_link_libraries(sdl2_final INTERFACE Mincore version Winmm)
+        target_link_libraries(sdl2_final INTERFACE version Winmm)
     endif()
 else()
     set(SDL2_LINK "" PARENT_SCOPE)


### PR DESCRIPTION
It doesn't seem to be used anywhere, as code compiles just fine without it. Decaf should now run on older versions of Windows.