### PR TITLE
Fix the Windows binary link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find us for developer discussion at #wiiu-emu on freenode.
 
 ## Binaries
 The latest Windows AppVeyor build is available from:
-- https://ci.appveyor.com/api/projects/exjam/decaf-emu/artifacts/decaf-bin.zip?branch=master
+- https://ci.appveyor.com/project/exjam/decaf-emu/build/artifacts
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find us for developer discussion at #wiiu-emu on freenode.
 
 ## Binaries
 The latest Windows AppVeyor build is available from:
-- https://ci.appveyor.com/project/exjam/decaf-emu/build/artifacts
+- https://ci.appveyor.com/project/exjam/decaf-emu/build/artifacts?branch=master
 
 ## Building from Source
 


### PR DESCRIPTION
Previously, this link was completely incorrect. Should be fixed now.