### PR TITLE
Compile fix for pm4-replay-qt

### DIFF
--- a/tools/pm4-replay-qt/replay.cpp
+++ b/tools/pm4-replay-qt/replay.cpp
@@ -135,7 +135,7 @@ getCommandName(ReplayIndex::Command &command)
    case PacketType::Type3:
    {
       auto header3 = HeaderType3::get(command.header.value);
-      return latte::pm4::enumAsString(header3.opcode());
+      return latte::pm4::to_string(header3.opcode());
    }
    default:
       return "Unknown";


### PR DESCRIPTION
Hi there, I was checking the project out of interest, and found if DECAF_QT was enabled, pm4-replay-qt would fail to compile (on windows). I believe I resolved the issue but I just started looking at the code, so please check if my fix is correct.