### PR TITLE
wiiu-rpc: Fix compatibility for newer wut versions

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -23,8 +23,7 @@ if(DEVKITPPC AND WUT_ROOT)
       CMAKE_GENERATOR "Unix Makefiles"
       CMAKE_CACHE_ARGS
          -DDEVKITPPC:string=${DEVKITPPC}
-         -DWUT_ROOT:string=${WUT_ROOT}
-         -DCMAKE_TOOLCHAIN_FILE:string=${WUT_ROOT}/cmake/wut-toolchain.cmake)
+         -DWUT_ROOT:string=${WUT_ROOT})
    set_target_properties(wiiu-rpc PROPERTIES FOLDER tools)
 
    externalproject_add_step(wiiu-rpc forcebuild

--- a/tools/wiiu-rpc/CMakeLists.txt
+++ b/tools/wiiu-rpc/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.2)
+set(CMAKE_TOOLCHAIN_FILE $ENV{WUT_ROOT}/share/wut.toolchain.cmake)
 project(wiiu-rpc)
+include("${WUT_ROOT}/share/wut.cmake" REQUIRED)
 
 set(CMAKE_C_STANDARD 99)
 
-add_rpx_lite(wiiu-rpc
+add_executable(wiiu-rpc
     src/main.c
     src/console.c
     src/server.c
@@ -11,9 +13,13 @@ add_rpx_lite(wiiu-rpc
 
 target_link_libraries(wiiu-rpc
     whb
-    defaultheap
     coreinit
     sysapp
     nsysnet
     nn_ac
     proc_ui)
+
+wut_enable_newlib(wiiu-rpc)
+wut_default_malloc(wiiu-rpc)
+
+wut_create_rpx(wiiu-rpc.rpx wiiu-rpc)

--- a/tools/wiiu-rpc/src/console.c
+++ b/tools/wiiu-rpc/src/console.c
@@ -1,9 +1,9 @@
 #include "console.h"
 
-#include <coreinit/baseheap.h>
 #include <coreinit/cache.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/frameheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
+#include <coreinit/memfrmheap.h>
 #include <coreinit/screen.h>
 
 #include <string.h>

--- a/tools/wiiu-rpc/src/main.c
+++ b/tools/wiiu-rpc/src/main.c
@@ -4,8 +4,8 @@
 
 #include <coreinit/core.h>
 #include <coreinit/dynload.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/baseheap.h>
+#include <coreinit/memexpheap.h>
+#include <coreinit/memheap.h>
 #include <coreinit/filesystem.h>
 #include <coreinit/ios.h>
 #include <coreinit/screen.h>
@@ -13,7 +13,7 @@
 #include <coreinit/time.h>
 #include <coreinit/foreground.h>
 #include <coreinit/systeminfo.h>
-#include <nn_ac/nn_ac.h>
+#include <nn/ac/ac_c.h>
 #include <nsysnet/socket.h>
 #include <sysapp/launch.h>
 #include <whb/crash.h>
@@ -104,7 +104,7 @@ packetHandler(Server *server, PacketReader *packet)
    case CMD_DYNLOAD_ACQUIRE:
    {
       const char *name = pakReadString(packet);
-      OSDynLoadModule module = NULL;
+      OSDynLoad_Module module = NULL;
       int result;
 
       WHBLogPrintf("OSDynLoad_Acquire(\"%s\")", name);
@@ -119,7 +119,7 @@ packetHandler(Server *server, PacketReader *packet)
    }
    case CMD_DYNLOAD_RELEASE:
    {
-      OSDynLoadModule *module = (OSDynLoadModule *)pakReadPointer(packet);
+      OSDynLoad_Module *module = (OSDynLoad_Module *)pakReadPointer(packet);
 
       WHBLogPrintf("OSDynLoad_Release(%p)", module);
       OSDynLoad_Release(module);
@@ -131,7 +131,7 @@ packetHandler(Server *server, PacketReader *packet)
    }
    case CMD_DYNLOAD_FINDEXPORT:
    {
-      OSDynLoadModule *module = (OSDynLoadModule *)pakReadPointer(packet);
+      OSDynLoad_Module *module = (OSDynLoad_Module *)pakReadPointer(packet);
       int32_t isData = pakReadInt32(packet);
       const char *name = pakReadString(packet);
       void *addr = NULL;
@@ -325,7 +325,7 @@ main(int argc, char **argv)
       while(WHBProcIsRunning()) {
          consoleDraw();
          serverProcess(&server, &packetHandler);
-         OSSleepTicks(OSMilliseconds(30));
+         OSSleepTicks(OSMillisecondsToTicks(30));
       }
    } else {
       WHBLogPrintf("Failed to start server.");

--- a/tools/wiiu-rpc/src/server.c
+++ b/tools/wiiu-rpc/src/server.c
@@ -2,11 +2,12 @@
 #include "console.h"
 #include "packet.h"
 
-#include <coreinit/baseheap.h>
-#include <coreinit/expandedheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
 #include <nsysnet/socket.h>
-#include <nn_ac/nn_ac.h>
+#include <nn/ac/ac_c.h>
 #include <string.h>
+#include <stdbool.h>
 #include <whb/log.h>
 
 int


### PR DESCRIPTION
Heyo!
So it turns out that if you have a machine set up with wut, `-DDECAF_BUILD_TOOLS=ON` will always attempt to build wiiu-rpc. This commit fixes up that code to build with newer revisions of wut. I tested it, and the rpx actually works too! May come in handy, I guess.
Thanks!
Ash