### PR TITLE
vulkan: Minor compilation fixes and one possible bug

### DIFF
--- a/src/libgpu/src/spirv/spirv_cf.cpp
+++ b/src/libgpu/src/spirv/spirv_cf.cpp
@@ -170,18 +170,22 @@ void Transpiler::translateCf_LOOP_START_DX10(const ControlFlowInst &cf)
    auto stateVal = mSpv->createLoad(mSpv->stateVar());
 
    // If state is set to InactiveContinue, set it to Active
-   auto isInactiveContinue = mSpv->createBinOp(spv::OpIEqual, mSpv->boolType(),
-                                               stateVal,
-                                               mSpv->stateInactiveContinue());
-   auto ifBuilder = &spv::Builder::If { isInactiveContinue, spv::SelectionControlMaskNone, *mSpv };
-   mSpv->createStore(mSpv->stateActive(), mSpv->stateVar());
-   ifBuilder->makeEndIf();
+   {
+      auto isInactiveContinue = mSpv->createBinOp(spv::OpIEqual, mSpv->boolType(),
+                                                  stateVal,
+                                                  mSpv->stateInactiveContinue());
+      auto ifBuilder = spv::Builder::If { isInactiveContinue, spv::SelectionControlMaskNone, *mSpv };
+      mSpv->createStore(mSpv->stateActive(), mSpv->stateVar());
+      ifBuilder.makeEndIf();
+   }
 
    // If state is set to Inactive, set it to InactiveBreak
-   auto isInactive = mSpv->createBinOp(spv::OpIEqual, mSpv->boolType(), stateVal, mSpv->stateInactive());
-   ifBuilder = &spv::Builder::If { isInactive, spv::SelectionControlMaskNone, *mSpv };
-   mSpv->createStore(mSpv->stateInactiveBreak(), mSpv->stateVar());
-   ifBuilder->makeEndIf();
+   {
+      auto isInactive = mSpv->createBinOp(spv::OpIEqual, mSpv->boolType(), stateVal, mSpv->stateInactive());
+      auto ifBuilder = spv::Builder::If { isInactive, spv::SelectionControlMaskNone, *mSpv };
+      mSpv->createStore(mSpv->stateInactiveBreak(), mSpv->stateVar());
+      ifBuilder.makeEndIf();
+   }
 }
 
 void Transpiler::translateCf_LOOP_START_NO_AL(const ControlFlowInst &cf)

--- a/src/libgpu/src/vulkan/vulkan_driver.h
+++ b/src/libgpu/src/vulkan/vulkan_driver.h
@@ -13,6 +13,7 @@
 #include <condition_variable>
 #include <functional>
 #include <gsl/gsl>
+#include <list>
 #include <map>
 #include <mutex>
 #include <thread>
@@ -48,11 +49,6 @@ public:
    DataHash hash() const
    {
       return mHash;
-   }
-
-   operator bool() const
-   {
-      return !!mHash;
    }
 
    bool operator==(const HashedDesc<T>& other) const

--- a/src/libgpu/src/vulkan/vulkan_memcache.cpp
+++ b/src/libgpu/src/vulkan/vulkan_memcache.cpp
@@ -103,7 +103,7 @@ Driver::_allocMemCache(phys_addr address, const std::vector<uint32_t>& sectionSi
    VkBuffer buffer;
    VmaAllocation allocation;
    vmaCreateBuffer(mAllocator,
-                   &static_cast<VkBufferCreateInfo>(bufferDesc),
+                   reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
                    &allocInfo,
                    &buffer,
                    &allocation,

--- a/src/libgpu/src/vulkan/vulkan_staging.cpp
+++ b/src/libgpu/src/vulkan/vulkan_staging.cpp
@@ -31,7 +31,7 @@ Driver::allocTempBuffer(uint32_t size)
    VkBuffer buffer;
    VmaAllocation allocation;
    vmaCreateBuffer(mAllocator,
-                   &static_cast<VkBufferCreateInfo>(bufferDesc),
+                   reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
                    &allocDesc,
                    &buffer,
                    &allocation,

--- a/src/libgpu/src/vulkan/vulkan_surface.cpp
+++ b/src/libgpu/src/vulkan/vulkan_surface.cpp
@@ -181,24 +181,24 @@ Driver::_copySurface(SurfaceObject *dst, SurfaceObject *src, SurfaceSubRange ran
 
    vk::ImageCopy copyRegion;
    if (src->desc.dim == latte::SQ_TEX_DIM::DIM_3D) {
-      copyRegion.srcOffset = { 0, 0, static_cast<int32_t>(range.firstSlice) };
+      copyRegion.srcOffset = vk::Offset3D { 0, 0, static_cast<int32_t>(range.firstSlice) };
       copyRegion.srcSubresource = { copyAspect, 0, 0, 1 };
       // range.numSlices is expressed by the extent here...
    } else {
-      copyRegion.srcOffset = { 0, 0, 0 };
+      copyRegion.srcOffset = vk::Offset3D { 0, 0, 0 };
       copyRegion.srcSubresource = { copyAspect, 0, range.firstSlice, range.numSlices };
    }
    if (dst->desc.dim == latte::SQ_TEX_DIM::DIM_3D) {
-      copyRegion.dstOffset = { 0, 0, static_cast<int32_t>(range.firstSlice) };
+      copyRegion.dstOffset = vk::Offset3D { 0, 0, static_cast<int32_t>(range.firstSlice) };
       copyRegion.dstSubresource = { copyAspect, 0, 0, 1 };
       // range.numSlices is expressed by the extent here...
    } else {
-      copyRegion.dstOffset = { 0, 0, 0 };
+      copyRegion.dstOffset = vk::Offset3D { 0, 0, 0 };
       copyRegion.dstSubresource = { copyAspect, 0, range.firstSlice, range.numSlices };
 
       // range.numSlices is expressed by the extent here...
    }
-   copyRegion.extent = { copyWidth, copyHeight, copySlices };
+   copyRegion.extent = vk::Extent3D { copyWidth, copyHeight, copySlices };
 
    auto originalSrcUsage = src->activeUsage;
    auto originalSrcLayout = src->activeLayout;
@@ -477,10 +477,10 @@ Driver::_allocateSurface(const SurfaceDesc& info)
    bufferRegion.imageSubresource.baseArrayLayer = 0;
    bufferRegion.imageSubresource.layerCount = realArrayLayers;
 
-   bufferRegion.imageOffset = { 0, 0, 0 };
-   bufferRegion.imageExtent = { static_cast<uint32_t>(realWidth),
-                           static_cast<uint32_t>(realHeight),
-                           static_cast<uint32_t>(realDepth) };
+   bufferRegion.imageOffset = vk::Offset3D { 0, 0, 0 };
+   bufferRegion.imageExtent = vk::Extent3D { static_cast<uint32_t>(realWidth),
+                                             static_cast<uint32_t>(realHeight),
+                                             static_cast<uint32_t>(realDepth) };
 
    std::vector<SurfaceSlice> slices;
 


### PR DESCRIPTION
vulkan: Minor compilation fixes and one possible bug

Do not take address of temporaries.
Use proper casts when casting from Vulkan-Hpp to Vulkan.
Fix use of implicit conversions that make gcc not like it
due to overload ambiguity.
Remove unused bool cast operator, that called non existing
bool operator in other class.

Tested with vulkan 1.1.82 and 1.1.73, and gcc 8.2.