### PR TITLE
vulkan: Check results from AMD Vulkan Memory Allocator

### DIFF
--- a/src/libgpu/src/vulkan/vulkan_driver.cpp
+++ b/src/libgpu/src/vulkan/vulkan_driver.cpp
@@ -63,7 +63,7 @@ Driver::initialise(vk::PhysicalDevice physDevice, vk::Device device, vk::Queue q
    VmaAllocatorCreateInfo allocatorDesc = {};
    allocatorDesc.physicalDevice = mPhysDevice;
    allocatorDesc.device = mDevice;
-   vmaCreateAllocator(&allocatorDesc, &mAllocator);
+   CHECK_VK_RESULT(vmaCreateAllocator(&allocatorDesc, &mAllocator));
 
    // Set up our drawing pipeline layout
    auto makeStageSet = [&](int stageIndex)

--- a/src/libgpu/src/vulkan/vulkan_driver.h
+++ b/src/libgpu/src/vulkan/vulkan_driver.h
@@ -20,6 +20,15 @@
 #include <unordered_map>
 #include <vulkan/vulkan.hpp>
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+// Evaluate f and if result is not a success throw proper vk exception.
+#define CHECK_VK_RESULT(x) do { \
+   vk::Result res = vk::Result(x); \
+   vk::createResultValue(res, __FILE__ ":" TOSTRING(__LINE__)); \
+} while (0)
+
 namespace vulkan
 {
 

--- a/src/libgpu/src/vulkan/vulkan_memcache.cpp
+++ b/src/libgpu/src/vulkan/vulkan_memcache.cpp
@@ -102,12 +102,13 @@ Driver::_allocMemCache(phys_addr address, const std::vector<uint32_t>& sectionSi
 
    VkBuffer buffer;
    VmaAllocation allocation;
-   vmaCreateBuffer(mAllocator,
-                   reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
-                   &allocInfo,
-                   &buffer,
-                   &allocation,
-                   nullptr);
+   CHECK_VK_RESULT(
+      vmaCreateBuffer(mAllocator,
+                      reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
+                      &allocInfo,
+                      &buffer,
+                      &allocation,
+                      nullptr));
 
    static uint64_t memCacheIndex = 0;
    setVkObjectName(buffer, fmt::format("memcache_{}_{:08x}_{}", memCacheIndex++, address.getAddress(), totalSize).c_str());

--- a/src/libgpu/src/vulkan/vulkan_staging.cpp
+++ b/src/libgpu/src/vulkan/vulkan_staging.cpp
@@ -30,18 +30,19 @@ Driver::allocTempBuffer(uint32_t size)
 
    VkBuffer buffer;
    VmaAllocation allocation;
-   vmaCreateBuffer(mAllocator,
-                   reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
-                   &allocDesc,
-                   &buffer,
-                   &allocation,
-                   nullptr);
+   CHECK_VK_RESULT(
+      vmaCreateBuffer(mAllocator,
+                      reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
+                      &allocDesc,
+                      &buffer,
+                      &allocation,
+                      nullptr));
 
    static uint64_t stagingBufferIdx = 0;
    setVkObjectName(buffer, fmt::format("stagingbuffer_{}", stagingBufferIdx++).c_str());
 
    void *mappedPtr;
-   vmaMapMemory(mAllocator, allocation, &mappedPtr);
+   CHECK_VK_RESULT(vmaMapMemory(mAllocator, allocation, &mappedPtr));
 
    auto sbuffer = new StagingBuffer();
    sbuffer->maximumSize = size;


### PR DESCRIPTION
Just convert VkResult into vk::Result using Vulkan-Hpp library.
It will throw exception, if not a success.
Construct a message by using filename and line number.

These errors were previously ignored and lost.