### PR TITLE
Changes to allow decaf-cli to cleanly exit

### DIFF
--- a/src/decaf-cli/decafcli.cpp
+++ b/src/decaf-cli/decafcli.cpp
@@ -35,13 +35,13 @@ DecafCLI::run(const std::string &gamePath)
    std::condition_variable timeoutCV;
 
    if (config::system::timeout_ms) {
-      std::mutex timeoutMutex;
       auto timeout = std::chrono::system_clock::now() + std::chrono::milliseconds(config::system::timeout_ms);
 
       timeoutThread = std::thread {
          [&]() {
+            std::mutex timeoutMutex;
             std::unique_lock<std::mutex> lock { timeoutMutex };
-            timeoutCV.wait_until(lock, timeout, [&]() { return running.load(); });
+            timeoutCV.wait_until(lock, timeout, [&]() { return !running.load(); });
 
             if (running) {
                timedOut.store(true);

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel.cpp
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel.cpp
@@ -286,8 +286,6 @@ stop()
       sStopping = true;
       cpu::halt();
    }
-
-   cpu::join();
 }
 
 void

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel.cpp
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel.cpp
@@ -318,6 +318,14 @@ idleCoreLoop(cpu::Core *core)
 void
 exit()
 {
+   // Cafe kernel is about to exit - IOS threads should also stop.
+   auto error = IOS_Ioctl(RamPartitionId::Kernel,
+                          RamPartitionId::Invalid,
+                          getPpcAppHandle(),
+                          ios::mcp::PPCAppCommand::PowerOff,
+                          nullptr, 0,
+                          nullptr, 0);
+
    // Set the running flag to false so idle loops exit.
    sStopping = true;
 

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel.cpp
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel.cpp
@@ -276,6 +276,12 @@ hasExited()
 void
 join()
 {
+   cpu::join();
+}
+
+void
+stop()
+{
    if (!sStopping) {
       sStopping = true;
       cpu::halt();

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel.h
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel.h
@@ -18,6 +18,9 @@ start();
 void
 join();
 
+void
+stop();
+
 bool
 hasExited();
 

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel_ipc.cpp
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel_ipc.cpp
@@ -307,7 +307,7 @@ initialiseIpc()
                                   nameBuffer,
                                   ios::OpenMode::None);
 
-   string_copy(nameBuffer.get(), "/dev/mcp", 0x20);
+   string_copy(nameBuffer.get(), "/dev/ppc_app", 0x20);
    sIpcData->ppcAppHandle = IOS_Open(RamPartitionId::Kernel,
                                      nameBuffer,
                                      ios::OpenMode::None);
@@ -335,6 +335,18 @@ ios::Handle
 getMcpHandle()
 {
    return internal::sIpcData->mcpHandle;
+}
+
+ios::Handle
+getPpcAppHandle()
+{
+   return internal::sIpcData->ppcAppHandle;
+}
+
+ios::Handle
+getCblHandle()
+{
+   return internal::sIpcData->cblHandle;
 }
 
 } // namespace cafe::kernel

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel_ipc.h
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel_ipc.h
@@ -10,6 +10,12 @@ namespace cafe::kernel
 ios::Handle
 getMcpHandle();
 
+ios::Handle
+getPpcAppHandle();
+
+ios::Handle
+getCblHandle();
+
 namespace internal
 {
 

--- a/src/libdecaf/src/decaf.cpp
+++ b/src/libdecaf/src/decaf.cpp
@@ -216,10 +216,10 @@ shutdown()
    debugger::shutdown();
 
    // Wait for IOS to finish
-   ios::join();
+   //ios::join();
 
    // Wait for PPC to finish
-   cafe::kernel::join();
+   //cafe::kernel::join();
 
    // Stop graphics driver
    auto graphicsDriver = getGraphicsDriver();

--- a/src/libdecaf/src/decaf.cpp
+++ b/src/libdecaf/src/decaf.cpp
@@ -215,11 +215,11 @@ shutdown()
    // Shut down debugger
    debugger::shutdown();
 
-   // Wait for IOS to finish
-   //ios::join();
+   // Stop IOS
+   ios::stop();
 
-   // Wait for PPC to finish
-   //cafe::kernel::join();
+   // Stop PPC
+   cafe::kernel::stop();
 
    // Stop graphics driver
    auto graphicsDriver = getGraphicsDriver();

--- a/src/libdecaf/src/ios/ios.cpp
+++ b/src/libdecaf/src/ios/ios.cpp
@@ -22,9 +22,17 @@ start()
 void
 join()
 {
-   internal::joinWorkerThread();
-   internal::joinAlarmThread();
+   kernel::join();
+   internal::stopWorkerThread();
+   internal::stopAlarmThread();
+}
+
+void
+stop()
+{
    kernel::stop();
+   internal::stopWorkerThread();
+   internal::stopAlarmThread();
 }
 
 void

--- a/src/libdecaf/src/ios/ios.h
+++ b/src/libdecaf/src/ios/ios.h
@@ -11,6 +11,9 @@ void
 join();
 
 void
+stop();
+
+void
 setFileSystem(std::unique_ptr<::fs::FileSystem> fs);
 
 ::fs::FileSystem *

--- a/src/libdecaf/src/ios/ios_alarm_thread.cpp
+++ b/src/libdecaf/src/ios/ios_alarm_thread.cpp
@@ -20,7 +20,7 @@ static std::condition_variable
 sAlarmCondition;
 
 static std::atomic_bool
-sAlarmThreadRunning = true;
+sAlarmThreadRunning = false;
 
 static std::chrono::steady_clock::time_point
 sNextAlarm = std::chrono::steady_clock::time_point::max();
@@ -50,16 +50,20 @@ alarmThread()
 void
 startAlarmThread()
 {
-   sAlarmThreadRunning.store(true);
-   sAlarmThread = std::thread { alarmThread };
+   if(!sAlarmThreadRunning.load()) {
+      sAlarmThreadRunning.store(true);
+      sAlarmThread = std::thread { alarmThread };
+   }
 }
 
 void
 stopAlarmThread()
 {
-   sAlarmThreadRunning.store(false);
-   sAlarmCondition.notify_all();
-   sAlarmThread.join();
+   if(sAlarmThreadRunning.load()) {
+      sAlarmThreadRunning.store(false);
+      sAlarmCondition.notify_all();
+      sAlarmThread.join();
+   }
 }
 
 void

--- a/src/libdecaf/src/ios/ios_alarm_thread.cpp
+++ b/src/libdecaf/src/ios/ios_alarm_thread.cpp
@@ -55,7 +55,7 @@ startAlarmThread()
 }
 
 void
-joinAlarmThread()
+stopAlarmThread()
 {
    sAlarmThreadRunning.store(false);
    sAlarmCondition.notify_all();

--- a/src/libdecaf/src/ios/ios_alarm_thread.h
+++ b/src/libdecaf/src/ios/ios_alarm_thread.h
@@ -8,7 +8,7 @@ void
 startAlarmThread();
 
 void
-joinAlarmThread();
+stopAlarmThread();
 
 void
 setNextAlarm(std::chrono::steady_clock::time_point time);

--- a/src/libdecaf/src/ios/ios_worker_thread.cpp
+++ b/src/libdecaf/src/ios/ios_worker_thread.cpp
@@ -56,7 +56,7 @@ startWorkerThread()
 }
 
 void
-joinWorkerThread()
+stopWorkerThread()
 {
    sWorkerThreadRunning = false;
    sWorkerThreadConditionVariable.notify_all();

--- a/src/libdecaf/src/ios/ios_worker_thread.cpp
+++ b/src/libdecaf/src/ios/ios_worker_thread.cpp
@@ -51,17 +51,21 @@ iosWorkerThread()
 void
 startWorkerThread()
 {
-   sWorkerThreadRunning = true;
-   sWorkerThread = std::thread { iosWorkerThread };
+   if(!sWorkerThreadRunning) {
+      sWorkerThreadRunning = true;
+      sWorkerThread = std::thread { iosWorkerThread };
+   }
 }
 
 void
 stopWorkerThread()
 {
-   sWorkerThreadRunning = false;
-   sWorkerThreadConditionVariable.notify_all();
-   sWorkerThread.join();
-   sWorkerThreadTasks = {};
+   if(sWorkerThreadRunning) {
+      sWorkerThreadRunning = false;
+      sWorkerThreadConditionVariable.notify_all();
+      sWorkerThread.join();
+      sWorkerThreadTasks = {};
+   }
 }
 
 void

--- a/src/libdecaf/src/ios/ios_worker_thread.h
+++ b/src/libdecaf/src/ios/ios_worker_thread.h
@@ -9,7 +9,7 @@ void
 startWorkerThread();
 
 void
-joinWorkerThread();
+stopWorkerThread();
 
 void
 submitWorkerTask(WorkerTask task);

--- a/src/libdecaf/src/ios/kernel/ios_kernel.cpp
+++ b/src/libdecaf/src/ios/kernel/ios_kernel.cpp
@@ -324,7 +324,6 @@ void
 stop()
 {
    internal::stopHardwareThread();
-   internal::joinHardwareThread();
 }
 
 } // namespace ios::kernel

--- a/src/libdecaf/src/ios/kernel/ios_kernel.cpp
+++ b/src/libdecaf/src/ios/kernel/ios_kernel.cpp
@@ -324,6 +324,7 @@ void
 stop()
 {
    internal::stopHardwareThread();
+   internal::joinHardwareThread();
 }
 
 } // namespace ios::kernel

--- a/src/libdecaf/src/ios/kernel/ios_kernel.cpp
+++ b/src/libdecaf/src/ios/kernel/ios_kernel.cpp
@@ -315,9 +315,15 @@ start()
 }
 
 void
-stop()
+join()
 {
    internal::joinHardwareThread();
+}
+
+void
+stop()
+{
+   internal::stopHardwareThread();
 }
 
 } // namespace ios::kernel

--- a/src/libdecaf/src/ios/kernel/ios_kernel.h
+++ b/src/libdecaf/src/ios/kernel/ios_kernel.h
@@ -8,6 +8,9 @@ Error
 start();
 
 void
+join();
+
+void
 stop();
 
 } // namespace ios::kernel

--- a/src/libdecaf/src/ios/kernel/ios_kernel_hardware.cpp
+++ b/src/libdecaf/src/ios/kernel/ios_kernel_hardware.cpp
@@ -556,7 +556,6 @@ stopHardwareThread()
 {
    sRunning = false;
    sHardwareConditionVariable.notify_all();
-   sHardwareThread.join();
 }
 
 } // namespace internal

--- a/src/libdecaf/src/ios/kernel/ios_kernel_hardware.cpp
+++ b/src/libdecaf/src/ios/kernel/ios_kernel_hardware.cpp
@@ -548,6 +548,12 @@ startHardwareThread()
 void
 joinHardwareThread()
 {
+   sHardwareThread.join();
+}
+
+void
+stopHardwareThread()
+{
    sRunning = false;
    sHardwareConditionVariable.notify_all();
    sHardwareThread.join();

--- a/src/libdecaf/src/ios/kernel/ios_kernel_hardware.h
+++ b/src/libdecaf/src/ios/kernel/ios_kernel_hardware.h
@@ -98,6 +98,9 @@ void
 joinHardwareThread();
 
 void
+stopHardwareThread();
+
+void
 initialiseStaticHardwareData();
 
 } // namespace internal

--- a/src/libdecaf/src/ios/mcp/ios_mcp_enum.h
+++ b/src/libdecaf/src/ios/mcp/ios_mcp_enum.h
@@ -124,6 +124,12 @@ ENUM_BEG(PMCommand, uint32_t)
    ENUM_VALUE(RegisterResourceManager,    0xE1)
 ENUM_END(PMCommand)
 
+ENUM_BEG(PPCAppCommand, uint32_t)
+   ENUM_VALUE(StartupEvent,               0xB0)
+   ENUM_VALUE(PowerOff,                   0xB2)
+   ENUM_VALUE(UnrecoverableError,         0xB3)
+ENUM_END(PPCAppCommand)
+
 ENUM_BEG(ResourceManagerCommand, int32_t)
    ENUM_VALUE(Timeout,                    -32)  // ios::Error::Timeout
    ENUM_VALUE(ResumeReply,                8)    // ios::Command::Reply


### PR DESCRIPTION
While trying to run the test suite changes in my other PR, I found that `decaf-cli` was exiting before the test program had even started running, and was not spitting out any error messages.

I found that this was because `decaf::waitForExit()` calls `ios::join()` and `cafe::kernel::join()` which signal the respective module threads to start shutting down, before they have even started running the program.

This would also result in a crash because `decaf::waitForExit()` used to call `decaf::shutdown()`, which also tries to join the IOS/Kernel threads, resulting in `std::__1::system_error` being thrown because an already terminated thread cannot be joined.

I implemented new exit functionality to halt the main thread until `sStopping` in `src/libdecaf/src/cafe/kernel/cafe_kernel.cpp` is set to `true` using an `std::condition_variable`.

Because a condition variable is now used to exit `decaf-cli` upon the emulated program's return, the process of exiting `decaf-cli` upon a specified timeout can be much more cleanly implemented as well. This new timeout code also solves an `std::__1::system_error` I was experiencing due to a fault in `std::mutex` usage that I couldn't locate.

This is my first time working with C++ threading features, so feedback is appreciated. 🙂