### PR TITLE
Updates to test suites and RPC server/client

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,7 @@ if(DECAF_BUILD_WUT_TESTS)
         CMAKE_CACHE_ARGS
             -DDEVKITPPC:string=${DEVKITPPC}
             -DWUT_ROOT:string=${WUT_ROOT}
-            -DCMAKE_TOOLCHAIN_FILE:string=${WUT_ROOT}/cmake/wut-toolchain.cmake)
+            -DCMAKE_TOOLCHAIN_FILE:string=${WUT_ROOT}/share/wut.toolchain.cmake)
     externalproject_get_property(hle-rpx BINARY_DIR)
     set_target_properties(hle-rpx PROPERTIES FOLDER tests)
     add_dependencies(hle-rpx hle-content)

--- a/tests/cpu/runner-achurch/main.cpp
+++ b/tests/cpu/runner-achurch/main.cpp
@@ -7,6 +7,7 @@
 #include <libcpu/mem.h>
 #include <memory>
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_sinks.h>
 
 std::shared_ptr<spdlog::logger>
 gLog;
@@ -95,7 +96,7 @@ int main(int argc, char *argv[])
 
    // We need to run the tests on a core.
    cpu::setCoreEntrypointHandler(
-      [&runResult]() {
+      [&runResult](cpu::Core *core) {
          if (cpu::this_core::id() == 1) {
             // Run the tests on only a single core.
             runResult = runTests();

--- a/tests/cpu/runner-generated/hardwaretests.h
+++ b/tests/cpu/runner-generated/hardwaretests.h
@@ -5,7 +5,6 @@
 #include <libcpu/state.h>
 #include <libcpu/espresso/espresso_instruction.h>
 #include <libcpu/espresso/espresso_registerformats.h>
-#include <common/be_val.h>
 
 namespace hwtest
 {

--- a/tests/cpu/runner-generated/main.cpp
+++ b/tests/cpu/runner-generated/main.cpp
@@ -6,6 +6,7 @@
 #include <libcpu/mem.h>
 #include <memory>
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_sinks.h>
 
 std::shared_ptr<spdlog::logger>
 gLog;
@@ -22,7 +23,7 @@ int main(int argc, char *argv[])
 
    // We need to run the tests on a core.
    cpu::setCoreEntrypointHandler(
-      []() {
+      [](cpu::Core *core) {
          if (cpu::this_core::id() == 1) {
             // Run the tests on only a single core.
             runResult = hwtest::runTests("data/wiiu");

--- a/tests/hle/coreinit/CMakeLists.txt
+++ b/tests/hle/coreinit/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 project(coreinit)
+include(${WUT_ROOT}/share/wut.cmake REQUIRED)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -7,8 +8,9 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 if(NOT COMMAND add_coreinit_test)
 macro(add_coreinit_test source)
    get_filename_component(name ${source} NAME_WE)
-   add_rpx_lite(${name} ${source})
+   add_executable(${name} ${source})
    target_link_libraries(${name} coreinit)
+   wut_create_rpx(${name}.rpx ${name})
 endmacro()
 endif()
 

--- a/tests/hle/coreinit/alarm/alarm_cancel.c
+++ b/tests/hle/coreinit/alarm/alarm_cancel.c
@@ -13,10 +13,10 @@ AlarmCallback(OSAlarm *alarm, OSContext *context)
 int main(int argc, char **argv)
 {
    OSCreateAlarmEx(&sAlarm, "Simple_Alarm");
-   OSSetAlarm(&sAlarm, OSMilliseconds(50), &AlarmCallback);
+   OSSetAlarm(&sAlarm, OSMillisecondsToTicks(50), &AlarmCallback);
    OSCancelAlarm(&sAlarm);
 
    // Sleep until after alarm was due to go off to test cancellation.
-   OSSleepTicks(OSMilliseconds(100));
+   OSSleepTicks(OSMillisecondsToTicks(100));
    return 0;
 }

--- a/tests/hle/coreinit/alarm/alarm_cancel_group.c
+++ b/tests/hle/coreinit/alarm/alarm_cancel_group.c
@@ -13,13 +13,13 @@ AlarmCallback(OSAlarm *alarm, OSContext *context)
 int main(int argc, char **argv)
 {
    OSCreateAlarmEx(&sAlarm, "Simple_Alarm");
-   OSSetAlarm(&sAlarm, OSMilliseconds(50), &AlarmCallback);
+   OSSetAlarm(&sAlarm, OSMillisecondsToTicks(50), &AlarmCallback);
 
    // Set alarm group and cancel the group
    OSSetAlarmTag(&sAlarm, 1337);
    OSCancelAlarms(1337);
 
    // Sleep until after alarm was due to go off to test cancellation.
-   OSSleepTicks(OSMilliseconds(100));
+   OSSleepTicks(OSMillisecondsToTicks(100));
    return 0;
 }

--- a/tests/hle/coreinit/alarm/alarm_multithread.c
+++ b/tests/hle/coreinit/alarm/alarm_multithread.c
@@ -36,7 +36,7 @@ CoreEntryPoint0(int argc, const char **argv)
 {
    OSAlarm alarm;
    OSCreateAlarmEx(&alarm, "Core0_Alarm");
-   OSSetAlarm(&alarm, OSMilliseconds(225), &Core0AlarmHandler);
+   OSSetAlarm(&alarm, OSMillisecondsToTicks(225), &Core0AlarmHandler);
    OSWaitAlarm(&alarm);
 
    test_assert(core0Fired);
@@ -49,8 +49,8 @@ CoreEntryPoint2(int argc, const char **argv)
 {
    OSAlarm alarm;
    OSCreateAlarmEx(&alarm, "Core2_Alarm");
-   OSSetAlarm(&alarm, OSMilliseconds(125), &Core2AlarmHandler);
-   OSSleepTicks(OSMilliseconds(175));
+   OSSetAlarm(&alarm, OSMillisecondsToTicks(125), &Core2AlarmHandler);
+   OSSleepTicks(OSMillisecondsToTicks(175));
 
    test_assert(core2Fired);
    test_report("Core2 finished");
@@ -63,8 +63,8 @@ main(int argc, char **argv)
    OSAlarm periodicAlarm;
    OSCreateAlarmEx(&periodicAlarm, "PeriodicAlarm");
    OSSetPeriodicAlarm(&periodicAlarm,
-                      OSGetTime() + OSMilliseconds(50),
-                      OSMilliseconds(50),
+                      OSGetTime() + OSMillisecondsToTicks(50),
+                      OSMillisecondsToTicks(50),
                       &PeriodicAlarmHandler);
 
    test_assert(OSGetCoreId() == 1);

--- a/tests/hle/coreinit/alarm/alarm_multithread.c
+++ b/tests/hle/coreinit/alarm/alarm_multithread.c
@@ -6,6 +6,13 @@
 #include <coreinit/time.h>
 #include <coreinit/systeminfo.h>
 
+#define STACK_SIZE 4096
+
+OSThread threadCore0 = { 0 };
+OSThread threadCore2 = { 0 };
+uint8_t stackCore0[STACK_SIZE] = { 0 };
+uint8_t stackCore2[STACK_SIZE] = { 0 };
+
 int periodicFireCount = 0;
 BOOL core0Fired = FALSE;
 BOOL core2Fired = FALSE;
@@ -70,17 +77,17 @@ main(int argc, char **argv)
    test_assert(OSGetCoreId() == 1);
 
    // Run thread on core 0
-   OSThread *threadCore0 = OSGetDefaultThread(0);
-   OSRunThread(threadCore0, CoreEntryPoint0, 0, NULL);
+   OSCreateThread(&threadCore0, CoreEntryPoint0, 0, NULL, stackCore0 + STACK_SIZE, STACK_SIZE, 20, OS_THREAD_ATTRIB_AFFINITY_CPU0);
+   OSResumeThread(&threadCore0);
 
    // Run thread on core 2
-   OSThread *threadCore2 = OSGetDefaultThread(2);
-   OSRunThread(threadCore2, CoreEntryPoint2, 2, NULL);
+   OSCreateThread(&threadCore2, CoreEntryPoint2, 0, NULL, stackCore2 + STACK_SIZE, STACK_SIZE, 20, OS_THREAD_ATTRIB_AFFINITY_CPU2);
+   OSResumeThread(&threadCore2);
 
    // Wait for threads to return
    int resultCore0 = -1, resultCore2 = -1;
-   OSJoinThread(threadCore0, &resultCore0);
-   OSJoinThread(threadCore2, &resultCore2);
+   OSJoinThread(&threadCore0, &resultCore0);
+   OSJoinThread(&threadCore2, &resultCore2);
 
    OSCancelAlarm(&periodicAlarm);
 

--- a/tests/hle/coreinit/alarm/alarm_periodic.c
+++ b/tests/hle/coreinit/alarm/alarm_periodic.c
@@ -24,14 +24,14 @@ int main(int argc, char **argv)
    // Start a periodic alarm
    OSCreateAlarmEx(&sPeriodicAlarm, "PeriodicAlarm");
    OSSetPeriodicAlarm(&sPeriodicAlarm,
-                      OSGetTime() + OSMilliseconds(10),
-                      OSMilliseconds(10),
+                      OSGetTime() + OSMillisecondsToTicks(10),
+                      OSMillisecondsToTicks(10),
                       &AlarmCallback);
 
    // Wait for 100ms to allow periodic alarm to fire.
    OSAlarm alarm;
    OSCreateAlarmEx(&alarm, "TestAlarm");
-   OSSetAlarm(&alarm, OSMilliseconds(100), NULL);
+   OSSetAlarm(&alarm, OSMillisecondsToTicks(100), NULL);
    OSWaitAlarm(&alarm);
 
    test_report("Alarm fired count: %d", sAlarmFiredCount);

--- a/tests/hle/coreinit/alarm/alarm_simple.c
+++ b/tests/hle/coreinit/alarm/alarm_simple.c
@@ -16,11 +16,11 @@ int main(int argc, char **argv)
    OSCreateAlarm(&sAlarm);
 
    // Test with valid alarm callback
-   OSSetAlarm(&sAlarm, OSMilliseconds(50), &AlarmCallback);
+   OSSetAlarm(&sAlarm, OSMillisecondsToTicks(50), &AlarmCallback);
    OSWaitAlarm(&sAlarm);
 
    // Test with NULL alarm callback
-   OSSetAlarm(&sAlarm, OSMilliseconds(50), NULL);
+   OSSetAlarm(&sAlarm, OSMillisecondsToTicks(50), NULL);
    OSWaitAlarm(&sAlarm);
    return 0;
 }

--- a/tests/hle/coreinit/alarm/alarm_user_data.c
+++ b/tests/hle/coreinit/alarm/alarm_user_data.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
    int testData = USER_DATA_VALUE;
    OSCreateAlarm(&sAlarm);
    OSSetAlarmUserData(&sAlarm, &testData);
-   OSSetAlarm(&sAlarm, OSMilliseconds(50), &AlarmCallback);
+   OSSetAlarm(&sAlarm, OSMillisecondsToTicks(50), &AlarmCallback);
    OSWaitAlarm(&sAlarm);
    return 0;
 }

--- a/tests/hle/coreinit/memory/blockheap_simple.c
+++ b/tests/hle/coreinit/memory/blockheap_simple.c
@@ -1,7 +1,7 @@
 #include <hle_test.h>
-#include <coreinit/baseheap.h>
-#include <coreinit/blockheap.h>
-#include <coreinit/expandedheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memblockheap.h>
+#include <coreinit/memexpheap.h>
 
 static const uint32_t
 TrackSize = 1024;
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
    test_assert(trackAddr);
 
    test_report("Creating block heap at %p", heapStart);
-   MEMBlockHeap *blockHeap = MEMInitBlockHeap(&blockHeapStorage, heapStart, heapEnd, trackAddr, TrackSize, 0);
+   MEMHeapHandle blockHeap = MEMInitBlockHeap(&blockHeapStorage, heapStart, heapEnd, trackAddr, TrackSize, 0);
    test_assert(blockHeap);
 
    uint32_t freeSize1 = MEMGetTotalFreeSizeForBlockHeap(blockHeap);

--- a/tests/hle/coreinit/memory/frameheap_multi.c
+++ b/tests/hle/coreinit/memory/frameheap_multi.c
@@ -1,7 +1,7 @@
 #include <hle_test.h>
-#include <coreinit/baseheap.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/frameheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
+#include <coreinit/memfrmheap.h>
 
 static const uint32_t
 HeapSize = 1024 * 1024;
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
    test_assert(heapAddr);
 
    test_report("Creating frame heap at %p", heapAddr);
-   MEMFrameHeap *frameHeap = MEMCreateFrmHeapEx(heapAddr, HeapSize, 0);
+   MEMHeapHandle frameHeap = MEMCreateFrmHeapEx(heapAddr, HeapSize, 0);
    test_assert(frameHeap);
 
    uint32_t freeSizeInitial = MEMGetAllocatableSizeForFrmHeapEx(frameHeap, 4);
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
    test_report("Free Size after tail allocations: %d", freeSize);
 
    // Free head memory
-   MEMFreeToFrmHeap(frameHeap, MEM_FRAME_HEAP_FREE_HEAD);
+   MEMFreeToFrmHeap(frameHeap, MEM_FRM_HEAP_FREE_HEAD);
    freeSize += AllocationSize * HeadAllocations;
 
    uint32_t freeSizeAfterHeadFree = MEMGetAllocatableSizeForFrmHeapEx(frameHeap, 4);
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
    test_assert(freeSizeAfterHeadFree == freeSize);
 
    // Free tail memory
-   MEMFreeToFrmHeap(frameHeap, MEM_FRAME_HEAP_FREE_TAIL);
+   MEMFreeToFrmHeap(frameHeap, MEM_FRM_HEAP_FREE_TAIL);
    freeSize += AllocationSize * TailAllocations;
 
    uint32_t freeSizeAfterTailFree = MEMGetAllocatableSizeForFrmHeapEx(frameHeap, 4);

--- a/tests/hle/coreinit/memory/frameheap_simple.c
+++ b/tests/hle/coreinit/memory/frameheap_simple.c
@@ -1,7 +1,7 @@
 #include <hle_test.h>
-#include <coreinit/baseheap.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/frameheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
+#include <coreinit/memfrmheap.h>
 
 static const uint32_t
 HeapSize = 1024 * 1024;
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
    test_assert(heapAddr);
 
    test_report("Creating frame heap at %p", heapAddr);
-   MEMFrameHeap *frameHeap = MEMCreateFrmHeapEx(heapAddr, HeapSize, 0);
+   MEMHeapHandle frameHeap = MEMCreateFrmHeapEx(heapAddr, HeapSize, 0);
    test_assert(frameHeap);
 
    uint32_t freeSize1 = MEMGetAllocatableSizeForFrmHeapEx(frameHeap, 4);
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
    }
 
    // Free all memory
-   MEMFreeToFrmHeap(frameHeap, MEM_FRAME_HEAP_FREE_ALL);
+   MEMFreeToFrmHeap(frameHeap, MEM_FRM_HEAP_FREE_ALL);
 
    uint32_t freeSize3 = MEMGetAllocatableSizeForFrmHeapEx(frameHeap, 4);
    test_report("Free Size after free: %d", freeSize3);

--- a/tests/hle/coreinit/memory/frameheap_unaligned.c
+++ b/tests/hle/coreinit/memory/frameheap_unaligned.c
@@ -1,7 +1,7 @@
 #include <hle_test.h>
-#include <coreinit/baseheap.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/frameheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
+#include <coreinit/memfrmheap.h>
 
 static const uint32_t
 HeapSize = (1024 * 1024) + 1;
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
    // Unalign the frame heap base address
    void *frameHeapAddr = heapAddr + 1;
    test_report("Creating frame heap at %p", frameHeapAddr);
-   MEMFrameHeap *frameHeap = MEMCreateFrmHeapEx(frameHeapAddr, HeapSize, 0);
+   MEMHeapHandle frameHeap = MEMCreateFrmHeapEx(frameHeapAddr, HeapSize, 0);
    test_report("Frame heap created at %p", frameHeap);
    test_assert(frameHeap);
    test_assert((((uint32_t)frameHeap) % 4) == 0);
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
    }
 
    // Free all memory
-   MEMFreeToFrmHeap(frameHeap, MEM_FRAME_HEAP_FREE_ALL);
+   MEMFreeToFrmHeap(frameHeap, MEM_FRM_HEAP_FREE_ALL);
 
    uint32_t freeSize3 = MEMGetAllocatableSizeForFrmHeapEx(frameHeap, 4);
    test_report("Free Size after free: %d", freeSize3);

--- a/tests/hle/coreinit/messagequeue/messagequeue_receive_block.c
+++ b/tests/hle/coreinit/messagequeue/messagequeue_receive_block.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
    OSResumeThread(&sThread);
 
    // Make sure other thread gets to a blocking read
-   OSSleepTicks(OSMilliseconds(10));
+   OSSleepTicks(OSMillisecondsToTicks(10));
 
    // Sending message into empty queue should succeed.
    for (i = 0; i < NumMessages; ++i) {
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
    }
 
    // Make sure other thread gets a chance to read all messages.
-   OSSleepTicks(OSMilliseconds(10));
+   OSSleepTicks(OSMillisecondsToTicks(10));
    test_eq(sMessagesRead, NumMessages);
 
    return 0;

--- a/tests/hle/coreinit/messagequeue/messagequeue_send_full_block.c
+++ b/tests/hle/coreinit/messagequeue/messagequeue_send_full_block.c
@@ -16,7 +16,7 @@ int msgThreadEntry(int argc, const char **argv)
 {
    // Give main thread a chance to block on the message queue
    OSMessage msg;
-   OSSleepTicks(OSMilliseconds(10));
+   OSSleepTicks(OSMillisecondsToTicks(10));
 
    // Receive message
    test_eq(OSReceiveMessage(&sQueue, &msg, 0), TRUE);

--- a/tests/hle/coreinit/thread/thread_cancel.c
+++ b/tests/hle/coreinit/thread/thread_cancel.c
@@ -13,7 +13,7 @@ int cancelThreadEntry(int argc, const char **argv)
    while (1) {
       OSTime now = OSGetTime();
 
-      if (now - lastCheck >= OSMilliseconds(1)) {
+      if (now - lastCheck >= OSMillisecondsToTicks(1)) {
          OSTestThreadCancel();
          test_report("Cancel thread still running");
          lastCheck = now;
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
    OSResumeThread(&gThread);
 
    test_report("Main thread sleeping for 5 milliseconds");
-   OSSleepTicks(OSMilliseconds(5));
+   OSSleepTicks(OSMillisecondsToTicks(5));
 
    test_report("Try to cancel thread");
    OSCancelThread(&gThread);

--- a/tests/hle/gx2/CMakeLists.txt
+++ b/tests/hle/gx2/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 project(gx2)
+include(${WUT_ROOT}/share/wut.cmake REQUIRED)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -7,8 +8,9 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 if(NOT COMMAND add_gx2_test)
 macro(add_gx2_test source)
    get_filename_component(name ${source} NAME_WE)
-   add_rpx_lite(${name} ${source})
-   target_link_libraries(${name} whb gfd defaultheap coreinit gx2 proc_ui sysapp nsysnet)
+   add_executable(${name} ${source})
+   target_link_libraries(${name} whb gfd coreinit gx2 proc_ui sysapp nsysnet)
+   wut_create_rpx(${name}.rpx ${name})
 endmacro()
 endif()
 

--- a/tests/hle/gx2/draw/triangle.c
+++ b/tests/hle/gx2/draw/triangle.c
@@ -1,5 +1,5 @@
 #include <gfd.h>
-#include <defaultheap.h>
+#include <coreinit/memdefaultheap.h>
 #include <gx2/draw.h>
 #include <gx2/shaders.h>
 #include <gx2r/draw.h>

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -24,7 +24,7 @@ if(DEVKITPPC AND WUT_ROOT)
       CMAKE_CACHE_ARGS
          -DDEVKITPPC:string=${DEVKITPPC}
          -DWUT_ROOT:string=${WUT_ROOT}
-         -DCMAKE_TOOLCHAIN_FILE:string=${WUT_ROOT}/cmake/wut-toolchain.cmake)
+         -DCMAKE_TOOLCHAIN_FILE:string=${WUT_ROOT}/share/wut.toolchain.cmake)
    set_target_properties(wiiu-rpc PROPERTIES FOLDER tools)
 
    externalproject_add_step(wiiu-rpc forcebuild

--- a/tools/wiiu-rpc/CMakeLists.txt
+++ b/tools/wiiu-rpc/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.2)
 project(wiiu-rpc)
+include(${WUT_ROOT}/share/wut.cmake REQUIRED)
 
 set(CMAKE_C_STANDARD 99)
 
-add_rpx_lite(wiiu-rpc
+add_executable(wiiu-rpc
     src/main.c
     src/console.c
     src/server.c
@@ -11,9 +12,10 @@ add_rpx_lite(wiiu-rpc
 
 target_link_libraries(wiiu-rpc
     whb
-    defaultheap
     coreinit
     sysapp
     nsysnet
     nn_ac
     proc_ui)
+
+wut_create_rpx(wiiu-rpc.rpx wiiu-rpc)

--- a/tools/wiiu-rpc/CMakeLists.txt
+++ b/tools/wiiu-rpc/CMakeLists.txt
@@ -18,4 +18,5 @@ target_link_libraries(wiiu-rpc
     nn_ac
     proc_ui)
 
+wut_enable_newlib(wiiu-rpc)
 wut_create_rpx(wiiu-rpc.rpx wiiu-rpc)

--- a/tools/wiiu-rpc/client.py
+++ b/tools/wiiu-rpc/client.py
@@ -277,14 +277,16 @@ titleCount = MCP_TitleCount(handle)
 
 print "Title count: %d" % titleCount
 if titleCount > 0:
-   titleList = TmpOutData(titleCount * 0x61)
-   actualTitleCount = TmpOutData(4)
+   titleList = OutData(titleCount * 0x61)
+   actualTitleCount = OutData(4)
 
    result = MCP_TitleList(handle, actualTitleCount, titleList, titleCount * 0x61)
 
-   print result
-   print binascii.hexlify(actualTitleCount.data)
-   print binascii.hexlify(titleList.data)
+   if result == 0:
+      totalTitleCount = int(binascii.hexlify(actualTitleCount.data), 16)
+      print "Total number of titles: %d" % totalTitleCount
+      for i in range(0, totalTitleCount):
+         print "Title " + str(i) + " ID: " + binascii.hexlify(titleList.data[i*0x61:i*0x61+8])
 
 MCP_Close(handle)
 

--- a/tools/wiiu-rpc/src/console.c
+++ b/tools/wiiu-rpc/src/console.c
@@ -1,9 +1,9 @@
 #include "console.h"
 
-#include <coreinit/baseheap.h>
 #include <coreinit/cache.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/frameheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
+#include <coreinit/memfrmheap.h>
 #include <coreinit/screen.h>
 
 #include <string.h>

--- a/tools/wiiu-rpc/src/main.c
+++ b/tools/wiiu-rpc/src/main.c
@@ -4,8 +4,8 @@
 
 #include <coreinit/core.h>
 #include <coreinit/dynload.h>
-#include <coreinit/expandedheap.h>
-#include <coreinit/baseheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
 #include <coreinit/filesystem.h>
 #include <coreinit/ios.h>
 #include <coreinit/screen.h>
@@ -13,7 +13,7 @@
 #include <coreinit/time.h>
 #include <coreinit/foreground.h>
 #include <coreinit/systeminfo.h>
-#include <nn_ac/nn_ac.h>
+#include <nn/ac.h>
 #include <nsysnet/socket.h>
 #include <sysapp/launch.h>
 #include <whb/crash.h>
@@ -104,7 +104,7 @@ packetHandler(Server *server, PacketReader *packet)
    case CMD_DYNLOAD_ACQUIRE:
    {
       const char *name = pakReadString(packet);
-      OSDynLoadModule module = NULL;
+      OSDynLoad_Module module = NULL;
       int result;
 
       WHBLogPrintf("OSDynLoad_Acquire(\"%s\")", name);
@@ -119,7 +119,7 @@ packetHandler(Server *server, PacketReader *packet)
    }
    case CMD_DYNLOAD_RELEASE:
    {
-      OSDynLoadModule *module = (OSDynLoadModule *)pakReadPointer(packet);
+      OSDynLoad_Module *module = (OSDynLoad_Module *)pakReadPointer(packet);
 
       WHBLogPrintf("OSDynLoad_Release(%p)", module);
       OSDynLoad_Release(module);
@@ -131,7 +131,7 @@ packetHandler(Server *server, PacketReader *packet)
    }
    case CMD_DYNLOAD_FINDEXPORT:
    {
-      OSDynLoadModule *module = (OSDynLoadModule *)pakReadPointer(packet);
+      OSDynLoad_Module *module = (OSDynLoad_Module *)pakReadPointer(packet);
       int32_t isData = pakReadInt32(packet);
       const char *name = pakReadString(packet);
       void *addr = NULL;
@@ -325,7 +325,7 @@ main(int argc, char **argv)
       while(WHBProcIsRunning()) {
          consoleDraw();
          serverProcess(&server, &packetHandler);
-         OSSleepTicks(OSMilliseconds(30));
+         OSSleepTicks(OSMillisecondsToTicks(30));
       }
    } else {
       WHBLogPrintf("Failed to start server.");

--- a/tools/wiiu-rpc/src/server.c
+++ b/tools/wiiu-rpc/src/server.c
@@ -2,10 +2,11 @@
 #include "console.h"
 #include "packet.h"
 
-#include <coreinit/baseheap.h>
-#include <coreinit/expandedheap.h>
+#include <coreinit/memheap.h>
+#include <coreinit/memexpheap.h>
 #include <nsysnet/socket.h>
-#include <nn_ac/nn_ac.h>
+#include <nn/ac.h>
+#include <stdbool.h>
 #include <string.h>
 #include <whb/log.h>
 


### PR DESCRIPTION
The grunt of this PR is that the RPC client and HLE test cases were updated so that they can be built with WUT versions past `203dc66` (the current `legacy_cmake` branch)

In the case of the RPC client, I also updated the example `client.py` script such that the output of `MCP_TitleList` is printed out on screen more cleanly.

I also fixed some compiler errors in the CPU test cases which were likely the result of recent changes in `libcpu`.

And I changed the `alarm_multithread` test case such that, instead of using the default threads on cores 0 and 2 to run code, new threads are created. I did this because `OSJoinThread`, when used with the default core threads, seems to immediately return `FALSE` on-console, and throws an assertion failure error in Decaf. Using our own threads instead seems to resolve the error.

When combined with my other PR, all HLE test cases run and pass on my system, and almost all CPU tests pass as well.