### PR TITLE
cafe/hle: Properly initialize LibraryFunction fields

### DIFF
--- a/src/libdecaf/src/cafe/libraries/cafe_hle_library_function.h
+++ b/src/libdecaf/src/cafe/libraries/cafe_hle_library_function.h
@@ -13,9 +13,9 @@ namespace cafe::hle
 
 struct UnimplementedLibraryFunction
 {
-   class Library *library;
+   class Library *library = nullptr;
    std::string name;
-   uint32_t syscallID;
+   uint32_t syscallID = 0;
    virt_addr value;
 };
 
@@ -33,13 +33,13 @@ struct LibraryFunction : public LibrarySymbol
    virtual void call(cpu::Core *state) = 0;
 
    //! ID number of syscall.
-   uint32_t syscallID;
+   uint32_t syscallID = 0;
 
    //! Whether trace logging is enabled for this function or not.
    bool traceEnabled = true;
 
    //! Pointer to host function pointer, only set for internal functions.
-   virt_ptr<void> *hostPtr;
+   virt_ptr<void> *hostPtr = nullptr;
 };
 
 namespace internal
@@ -51,11 +51,11 @@ namespace internal
 template<typename FunctionType>
 struct LibraryFunctionCall : LibraryFunction
 {
+   LibraryFunctionCall(FunctionType func) : func(func) {}
+
    virtual ~LibraryFunctionCall()
    {
    }
-
-   FunctionType func;
 
    virtual void call(cpu::Core *state) override
    {
@@ -65,6 +65,8 @@ struct LibraryFunctionCall : LibraryFunction
 
       invoke(state, func);
    }
+
+   FunctionType func;
 };
 
 /**
@@ -121,8 +123,7 @@ template<typename FunctionType>
 inline std::unique_ptr<LibraryFunction>
 makeLibraryFunction(FunctionType func)
 {
-   auto libraryFunction = new LibraryFunctionCall<FunctionType>();
-   libraryFunction->func = func;
+   auto libraryFunction = new LibraryFunctionCall<FunctionType>(func);
    return std::unique_ptr<LibraryFunction> { libraryFunction };
 }
 


### PR DESCRIPTION
Most notably hostPtr might contain garbage, that will subsequently
lead to write to random memory location when doing relocations.

As a minor additional tweak, initialize LibraryFunctionCall::func
in constructor.

It took me a lot of time to find this out. I was getting consistent
crashes when trying to reloc ACConnect function, but couldn't
figure out easily how the random values got into hostPtr field.
Finally I tracked it with help of gdb and some dynamic watchpoints.