### PR TITLE
vulkan: Don't take the address of temporaries.

### DIFF
--- a/src/libgpu/src/vulkan/vulkan_driver.cpp
+++ b/src/libgpu/src/vulkan/vulkan_driver.cpp
@@ -249,7 +249,7 @@ Driver::initialiseBlankBuffer()
    VkBuffer emptyBuffer;
    VmaAllocation allocation;
    vmaCreateBuffer(mAllocator,
-                   &static_cast<VkBufferCreateInfo>(bufferDesc),
+                   reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
                    &allocInfo,
                    &emptyBuffer,
                    &allocation,

--- a/src/libgpu/src/vulkan/vulkan_streamout.cpp
+++ b/src/libgpu/src/vulkan/vulkan_streamout.cpp
@@ -45,7 +45,7 @@ Driver::allocateStreamContext(uint32_t initialOffset)
    VkBuffer buffer;
    VmaAllocation allocation;
    vmaCreateBuffer(mAllocator,
-                   &static_cast<VkBufferCreateInfo>(bufferDesc),
+                   reinterpret_cast<VkBufferCreateInfo*>(&bufferDesc),
                    &allocInfo,
                    &buffer,
                    &allocation,


### PR DESCRIPTION
GCC treats this as an error.