### PR TITLE
 Fixed a crash that was occurring when clicking the apply settings button

### DIFF
--- a/src/libconfig/src/loader_toml.cpp
+++ b/src/libconfig/src/loader_toml.cpp
@@ -105,6 +105,7 @@ saveToTOML(std::shared_ptr<cpptoml::table> config,
    if (config.use_count() > 0) {
       debugger = config->get_table("debugger");
    }
+
    if (!debugger) {
       debugger = cpptoml::make_table();
    }


### PR DESCRIPTION
When I clicked the apply settings buttons, decaf would crash calling get_table().  I now check if the config pointer is empty before making the call.