### PR TITLE
 Fixed a crash that occurred when applying settings.

### DIFF
--- a/src/decaf-qt/settings.cpp
+++ b/src/decaf-qt/settings.cpp
@@ -46,6 +46,7 @@ saveSettings(const std::string &path,
       // Read current file and modify that
       toml = cpptoml::parse_file(path);
    } catch (cpptoml::parse_exception ex) {
+      toml = cpptoml::make_table();
    }
 
    // Update it

--- a/src/libconfig/src/loader_toml.cpp
+++ b/src/libconfig/src/loader_toml.cpp
@@ -100,11 +100,11 @@ saveToTOML(std::shared_ptr<cpptoml::table> config,
            const decaf::Settings &decafSettings)
 {
    // debugger
-   std::shared_ptr<cpptoml::table> debugger;
+   std::shared_ptr<cpptoml::table> debugger = nullptr;
+
    if (config.use_count() > 0) {
       debugger = config->get_table("debugger");
    }
-      
    if (!debugger) {
       debugger = cpptoml::make_table();
    }

--- a/src/libconfig/src/loader_toml.cpp
+++ b/src/libconfig/src/loader_toml.cpp
@@ -100,7 +100,11 @@ saveToTOML(std::shared_ptr<cpptoml::table> config,
            const decaf::Settings &decafSettings)
 {
    // debugger
-   auto debugger = config->get_table("debugger");
+   std::shared_ptr<cpptoml::table> debugger;
+   if (config.use_count() > 0) {
+      debugger = config->get_table("debugger");
+   }
+      
    if (!debugger) {
       debugger = cpptoml::make_table();
    }

--- a/src/libconfig/src/loader_toml.cpp
+++ b/src/libconfig/src/loader_toml.cpp
@@ -105,6 +105,7 @@ saveToTOML(std::shared_ptr<cpptoml::table> config,
    if (config.use_count() > 0) {
       debugger = config->get_table("debugger");
    }
+
    if (!debugger) {
       debugger = cpptoml::make_table();
    }

--- a/src/libconfig/src/loader_toml.cpp
+++ b/src/libconfig/src/loader_toml.cpp
@@ -100,12 +100,7 @@ saveToTOML(std::shared_ptr<cpptoml::table> config,
            const decaf::Settings &decafSettings)
 {
    // debugger
-   std::shared_ptr<cpptoml::table> debugger = nullptr;
-
-   if (config.use_count() > 0) {
-      debugger = config->get_table("debugger");
-   }
-
+   auto debugger = config->get_table("debugger");
    if (!debugger) {
       debugger = cpptoml::make_table();
    }


### PR DESCRIPTION
When I clicked the apply settings buttons, decaf would crash if it failed to parse my config file.  When this happens I just create a new table.