### PR TITLE
Shader binaries dumping support

### DIFF
--- a/src/libconfig/src/loader_toml.cpp
+++ b/src/libconfig/src/loader_toml.cpp
@@ -65,6 +65,7 @@ loadFromTOML(std::shared_ptr<cpptoml::table> config,
    readValue(config, "gpu.debug", gpuSettings.debug.debug_enabled);
    readArray(config, "gpu.opengl_debug_filters", gpuSettings.opengl.debug_message_filters);
    readValue(config, "gpu.dump_shaders", gpuSettings.debug.dump_shaders);
+   readValue(config, "gpu.dump_shader_binaries_only", gpuSettings.debug.dump_shader_binaries_only);
    return true;
 }
 
@@ -190,6 +191,7 @@ saveToTOML(std::shared_ptr<cpptoml::table> config,
 
    gpu->insert("debug", gpuSettings.debug.debug_enabled);
    gpu->insert("dump_shaders", gpuSettings.debug.dump_shaders);
+   gpu->insert("dump_shader_binaries_only", gpuSettings.debug.dump_shader_binaries_only);
 
    auto debug_filters = cpptoml::make_array();
    for (auto &filter : gpuSettings.opengl.debug_message_filters) {

--- a/src/libdebugui/src/debugui_manager.cpp
+++ b/src/libdebugui/src/debugui_manager.cpp
@@ -449,6 +449,12 @@ void Manager::drawMenu()
          gpu::setConfig(newConfig);
       }
 
+      if (ImGui::MenuItem("GPU Dump Shader Binaries Only", nullptr, gpuConfig->debug.dump_shader_binaries_only, true)) {
+         auto newConfig = *gpuConfig;
+         newConfig.debug.dump_shader_binaries_only = !gpuConfig->debug.dump_shader_binaries_only;
+         gpu::setConfig(newConfig);
+      }
+
       ImGui::Separator();
 
       if (ImGui::MenuItem("JIT Profiling Enabled", JitProfileHotKey, mJitProfilingEnabled, true)) {

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -18,6 +18,7 @@ struct Gx2Settings
 {
    bool dump_textures = false;
    bool dump_shaders = false;
+   bool dump_shader_binaries_only = false;
 };
 
 struct LogSettings

--- a/src/libgpu/gpu_config.h
+++ b/src/libgpu/gpu_config.h
@@ -13,6 +13,9 @@ struct DebugSettings
 
    //! Dump shaders
    bool dump_shaders = false;
+
+   //! Only dump shader binaries
+   bool dump_shader_binaries_only = false;
 };
 
 struct OpenGLSettings

--- a/src/libgpu/src/vulkan/vulkan_driver.cpp
+++ b/src/libgpu/src/vulkan/vulkan_driver.cpp
@@ -51,6 +51,7 @@ Driver::initialise(vk::PhysicalDevice physDevice, vk::Device device, vk::Queue q
             [this](const gpu::Settings &settings) {
                mDebug = settings.debug.debug_enabled;
                mDumpShaders = settings.debug.dump_shaders;
+               mDumpShaderBinariesOnly = settings.debug.dump_shader_binaries_only;
             });
       });
 
@@ -58,6 +59,7 @@ Driver::initialise(vk::PhysicalDevice physDevice, vk::Device device, vk::Queue q
    auto gpuConfig = gpu::config();
    mDebug = gpuConfig->debug.debug_enabled;
    mDumpShaders = gpuConfig->debug.dump_shaders;
+   mDumpShaderBinariesOnly = gpuConfig->debug.dump_shader_binaries_only;
 
    mPhysDevice = physDevice;
    mDevice = device;

--- a/src/libgpu/src/vulkan/vulkan_driver.h
+++ b/src/libgpu/src/vulkan/vulkan_driver.h
@@ -791,6 +791,7 @@ private:
 
    bool mDebug;
    bool mDumpShaders;
+   bool mDumpShaderBinariesOnly;
    bool mDumpTextures;
 };
 

--- a/src/libgpu/src/vulkan/vulkan_shaders.cpp
+++ b/src/libgpu/src/vulkan/vulkan_shaders.cpp
@@ -261,7 +261,7 @@ static void dumpRawShaderBinaries(const ShaderBinaries &shaderBinaries, std::str
    }   
 }
 
-static void dumpRawShader(const spirv::ShaderDesc *desc)
+static void dumpRawShader(const spirv::ShaderDesc *desc, bool onlyDumpBinaries)
 {
    ShaderBinaries shaderBinaries;
 
@@ -292,7 +292,10 @@ static void dumpRawShader(const spirv::ShaderDesc *desc)
    // Dump binaries
 
    dumpRawShaderBinaries(shaderBinaries, shaderName);
-   
+
+   if (onlyDumpBinaries)
+      return;
+
    // Dump disassembly
 
    std::string outputStr;


### PR DESCRIPTION
* Intentionally only touched the Vulkan backend, only works there.
* New config option to _only_ dump binaries (instead of disassemblies and such). Reasoning is that we need to see binaries of shaders that decaf's latte disassembler doesn't understand yet.