### PR TITLE
Installation changes

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(resources)
 
 set(Fonts
@@ -5,9 +7,13 @@ set(Fonts
    fonts/CafeKr.ttf
    fonts/CafeStd.ttf
    fonts/CafeTw.ttf
-   fonts/NotoSansCJK.LICENSE
-   fonts/DejaVuSansMono.ttf
-   fonts/DejaVuSansMono.LICENSE)
+   fonts/DejaVuSansMono.ttf)
+set(Docs
+    fonts/DejaVuSansMono.LICENSE
+    fonts/NotoSansCJK.LICENSE
+    ../README.md
+    ../LICENSE.md)
+set(PARENT_PROJECT_NAME decaf-emu)
 
 set(ResourceFiles ${Fonts})
 
@@ -20,5 +26,13 @@ foreach(ResourceFile ${ResourceFiles})
                           $<TARGET_FILE_DIR:libdecaf>/resources/${ResourceFile})
 endforeach()
 
-install(FILES ${Fonts}
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/resources/fonts")
+if(DECAF_RESOURCES_PATH)
+  install(FILES ${Fonts} DESTINATION "${DECAF_RESOURCES_PATH}")
+else()
+  install(FILES ${Fonts}
+          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${PARENT_PROJECT_NAME}/resources/fonts")
+endif()
+
+if(DECAF_DOCS)
+  install(FILES ${Docs} DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PARENT_PROJECT_NAME}")
+endif()

--- a/src/decaf-cli/CMakeLists.txt
+++ b/src/decaf-cli/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(decaf-cli)
 
 include_directories(".")
@@ -14,4 +16,4 @@ target_link_libraries(decaf-cli
     cpptoml
     excmd)
 
-install(TARGETS decaf-cli RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS decaf-cli RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/decaf-qt/CMakeLists.txt
+++ b/src/decaf-qt/CMakeLists.txt
@@ -35,9 +35,11 @@ GroupSources(ui)
 target_include_directories(decaf-qt PRIVATE
    ${SDL2_INCLUDE_DIRS})
 
+target_link_libraries(decaf-qt common)
+if(DECAF_SDL)
+    target_link_libraries(decaf-qt common-sdl)
+endif()
 target_link_libraries(decaf-qt
-   common
-   common-sdl
    libconfig
    libcpu
    libdebugui

--- a/src/decaf-qt/CMakeLists.txt
+++ b/src/decaf-qt/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(decaf-qt)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -78,4 +80,4 @@ if(MSVC)
            $<TARGET_FILE_DIR:decaf-qt>)
 endif()
 
-install(TARGETS decaf-qt RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS decaf-qt RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/decaf-sdl/CMakeLists.txt
+++ b/src/decaf-sdl/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(decaf-sdl)
 
 include_directories(".")
@@ -39,4 +41,4 @@ if(MSVC)
         LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 endif()
 
-install(TARGETS decaf-sdl RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS decaf-sdl RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/src/libdebugui/src/debugui_manager.cpp
+++ b/src/libdebugui/src/debugui_manager.cpp
@@ -90,7 +90,7 @@ Manager::Manager(const std::string &configPath)
    static const ImWchar iconsRanges[] = { 0x2500, 0x25FF, 0 };
    auto config = ImFontConfig { };
    config.MergeMode = true;
-   auto fontPath = decaf::config()->system.resources_path + "/fonts/DejaVuSansMono.ttf";
+   auto fontPath = decaf::getResourcePath("fonts/DejaVuSansMono.ttf");
    io.Fonts->AddFontFromFileTTF(fontPath.c_str(), 13.0f, &config, iconsRanges);
 
    // Set default syle

--- a/src/libdecaf/CMakeLists.txt
+++ b/src/libdecaf/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(libdecaf)
 
 include_directories(".")
@@ -9,10 +11,8 @@ file(GLOB_RECURSE HEADER_FILES *.h)
 add_library(libdecaf STATIC ${SOURCE_FILES} ${HEADER_FILES})
 GroupSources(src)
 
-if(DECAF_RESOURCES_PATH)
-    set_property(TARGET libdecaf APPEND PROPERTY
-        COMPILE_DEFINITIONS DECAF_RESOURCES_PATH="${DECAF_RESOURCES_PATH}")
-endif()
+set_property(TARGET libdecaf APPEND PROPERTY
+    COMPILE_DEFINITIONS DECAF_PREFIX="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/decaf-emu")
 
 target_include_directories(libdecaf PRIVATE
     ${CURL_INCLUDE_DIRS})

--- a/src/libdecaf/CMakeLists.txt
+++ b/src/libdecaf/CMakeLists.txt
@@ -9,6 +9,11 @@ file(GLOB_RECURSE HEADER_FILES *.h)
 add_library(libdecaf STATIC ${SOURCE_FILES} ${HEADER_FILES})
 GroupSources(src)
 
+if(DECAF_RESOURCES_PATH)
+    set_property(TARGET libdecaf APPEND PROPERTY
+        COMPILE_DEFINITIONS DECAF_RESOURCES_PATH="${DECAF_RESOURCES_PATH}")
+endif()
+
 target_include_directories(libdecaf PRIVATE
     ${CURL_INCLUDE_DIRS})
 

--- a/src/libdecaf/decaf.h
+++ b/src/libdecaf/decaf.h
@@ -17,6 +17,9 @@ makeConfigPath(const std::string &filename);
 bool
 createConfigDirectory();
 
+std::string
+getResourcePath(const std::string &filename);
+
 bool
 initialise(const std::string &gamePath);
 

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -68,11 +68,7 @@ struct SystemSettings
    std::string sdcard_path = "sdcard";
    std::string hfio_path = "";
    std::string content_path = {};
-#ifndef DECAF_RESOURCES_PATH
    std::string resources_path = "resources";
-#else
-   std::string resources_path = DECAF_RESOURCES_PATH;
-#endif
    bool time_scale_enabled = false;
    double time_scale = 1.0;
    std::vector<std::string> lle_modules;

--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -68,7 +68,11 @@ struct SystemSettings
    std::string sdcard_path = "sdcard";
    std::string hfio_path = "";
    std::string content_path = {};
+#ifndef DECAF_RESOURCES_PATH
    std::string resources_path = "resources";
+#else
+   std::string resources_path = DECAF_RESOURCES_PATH;
+#endif
    bool time_scale_enabled = false;
    double time_scale = 1.0;
    std::vector<std::string> lle_modules;

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel_shareddata.cpp
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel_shareddata.cpp
@@ -2,6 +2,7 @@
 #include "cafe_kernel_shareddata.h"
 
 #include "decaf_config.h"
+#include "decaf.h"
 
 #include <common/align.h>
 #include <fstream>
@@ -49,7 +50,7 @@ loadResourcesFile(const char *filename,
                   SharedArea &area,
                   virt_addr addr)
 {
-   auto file = std::ifstream { decaf::config()->system.resources_path + "/fonts/" + filename,
+   auto file = std::ifstream { decaf::getResourcePath(std::string("/fonts/") + filename),
                                std::ifstream::in | std::ifstream::binary };
 
    if (!file.is_open()) {

--- a/src/libdecaf/src/decaf.cpp
+++ b/src/libdecaf/src/decaf.cpp
@@ -48,6 +48,27 @@ createConfigDirectory()
    return platform::createParentDirectories(makeConfigPath("."));
 }
 
+std::string
+getResourcePath(const std::string &filename)
+{
+#ifdef PLATFORM_WINDOWS
+   return decaf::config()->system.resources_path + "/" + filename;
+#else
+   std::string userPath = decaf::config()->system.resources_path + "/" + filename;
+   std::string systemPath = std::string(DECAF_PREFIX) + "/" + filename;
+
+   if (platform::fileExists(userPath)) {
+      return userPath;
+   }
+
+   if (platform::fileExists(systemPath)) {
+      return systemPath;
+   }
+
+   throw std::runtime_error("Failed to find resource");
+#endif
+}
+
 bool
 initialise(const std::string &gamePath)
 {

--- a/tools/gfd-tool/CMakeLists.txt
+++ b/tools/gfd-tool/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(gfd-tool)
 
 include_directories(".")
@@ -15,4 +17,4 @@ target_link_libraries(gfd-tool
     libgfd
     excmd)
 
-install(TARGETS gfd-tool RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS gfd-tool RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/latte-assembler/CMakeLists.txt
+++ b/tools/latte-assembler/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(latte-assembler)
 
 include_directories(".")
@@ -37,4 +39,4 @@ set_target_properties(latte-assembler PROPERTIES FOLDER tools)
 GroupSources(src)
 GroupSources(resources)
 
-install(TARGETS latte-assembler RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS latte-assembler RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/pm4-replay-qt/CMakeLists.txt
+++ b/tools/pm4-replay-qt/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(pm4-replay-qt)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -23,4 +25,4 @@ target_link_libraries(pm4-replay-qt
 
 target_link_libraries(pm4-replay-qt Qt5::Widgets)
 
-install(TARGETS pm4-replay-qt RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS pm4-replay-qt RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/pm4-replay/CMakeLists.txt
+++ b/tools/pm4-replay/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 project(pm4-replay)
 
 include_directories(".")
@@ -26,4 +28,4 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(pm4-replay X11)
 endif()
 
-install(TARGETS pm4-replay RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+install(TARGETS pm4-replay RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
This makes the installation and path handling a little more normal for a system install.

* All binaries including tools go in `${prefix}/bin` (normally `/usr/bin`)
* `-DDECAF_RESOURCES_PATH=/some-path/` can be used to set the default resources path
* If `DECAF_RESOURCES_PATH` is not set, all resources go to `${prefix}/share/decaf-emu/resources` (normally `/usr/share/...`)
* All documentation goes in `${prefix}/share/docs/decaf-emu`
* Although maybe useless, it is possible to build with `-DDECAF_QT=ON` and `DDECAF_SDL=OFF`. Just for consistency