### PR TITLE
Added the Git and Appveyor version information to the about dialog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,19 @@ macro(GroupSources curdir)
     endif()
 endmacro()
 
+# Gets a UTC timstamp and sets the provided variable to it
+function(get_timestamp _var)
+    string(TIMESTAMP timestamp UTC)
+    set(${_var} "${timestamp}" PARENT_SCOPE)
+endfunction()
+
+# generate git/build information
+include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REF_SPEC GIT_REV)
+git_describe(GIT_DESC --always --long --dirty)
+git_branch_name(GIT_BRANCH)
+get_timestamp(BUILD_DATE)
+
 add_subdirectory("libraries")
 add_subdirectory("src")
 add_subdirectory("resources")

--- a/CMakeModules/GetGitRevisionDescription.cmake
+++ b/CMakeModules/GetGitRevisionDescription.cmake
@@ -1,0 +1,158 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+			# We have reached the root directory, we are not in git
+			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			return()
+		endif()
+		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	endwhile()
+	# check if this is a submodule
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		file(READ ${GIT_DIR} submodule)
+		string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+		get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+		get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+	endif()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${GIT_DIR}/HEAD")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+		"${GIT_DATA}/grabRef.cmake"
+		@ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
+	set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+endfunction()
+
+function(git_branch_name _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		rev-parse --abbrev-ref HEAD
+		WORKING_DIRECTORY
+		"${CMAKE_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	#get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	#if(NOT hash)
+	#	set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+	#	return()
+	#endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		describe
+		${hash}
+		${ARGN}
+		WORKING_DIRECTORY
+		"${CMAKE_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()

--- a/CMakeModules/GetGitRevisionDescription.cmake.in
+++ b/CMakeModules/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,42 @@
+# 
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	elseif(EXISTS "@GIT_DIR@/logs/${HEAD_REF}")
+		configure_file("@GIT_DIR@/logs/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+		set(HEAD_HASH "${HEAD_REF}")
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	if(EXISTS "@GIT_DATA@/head-ref")
+		file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+		string(STRIP "${HEAD_HASH}" HEAD_HASH)
+	else()
+		set(HEAD_HASH "Unknown")
+	endif()
+endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,6 +2,25 @@ project(common)
 
 include_directories(".")
 
+set(BUILD_VERSION "0")
+if ($ENV{CI})
+  if ($ENV{TRAVIS})
+    set(BUILD_TAG $ENV{TRAVIS_TAG})
+  elseif($ENV{APPVEYOR})
+    set(BUILD_TAG $ENV{APPVEYOR_REPO_TAG_NAME})
+  endif()
+
+  if (BUILD_TAG)
+    string(REGEX MATCH "${CMAKE_MATCH_1}-([0-9]+)" OUTVAR ${BUILD_TAG})
+    if (${CMAKE_MATCH_COUNT} GREATER 0)
+	  set(BUILD_VERSION ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endif()
+  
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.cpp.in" "${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.cpp" @ONLY)
+
+
 file(GLOB_RECURSE SOURCE_FILES *.cpp)
 file(GLOB_RECURSE HEADER_FILES *.h)
 

--- a/src/common/scm_rev.cpp.in
+++ b/src/common/scm_rev.cpp.in
@@ -1,0 +1,26 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/scm_rev.h"
+
+#define GIT_REV      "@GIT_REV@"
+#define GIT_BRANCH   "@GIT_BRANCH@"
+#define GIT_DESC     "@GIT_DESC@"
+#define BUILD_NAME   "@REPO_NAME@"
+#define BUILD_DATE   "@BUILD_DATE@"
+#define BUILD_FULLNAME "@BUILD_FULLNAME@"
+#define BUILD_VERSION "@BUILD_VERSION@"
+
+namespace Common {
+
+const char g_scm_rev[]      = GIT_REV;
+const char g_scm_branch[]   = GIT_BRANCH;
+const char g_scm_desc[]     = GIT_DESC;
+const char g_build_name[]   = BUILD_NAME;
+const char g_build_date[]   = BUILD_DATE;
+const char g_build_fullname[] = BUILD_FULLNAME;
+const char g_build_version[]  = BUILD_VERSION;
+
+} // namespace
+

--- a/src/common/scm_rev.h
+++ b/src/common/scm_rev.h
@@ -1,0 +1,17 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Common {
+
+extern const char g_scm_rev[];
+extern const char g_scm_branch[];
+extern const char g_scm_desc[];
+extern const char g_build_name[];
+extern const char g_build_date[];
+extern const char g_build_fullname[];
+extern const char g_build_version[];
+
+} // namespace Common

--- a/src/decaf-qt/aboutdialog.h
+++ b/src/decaf-qt/aboutdialog.h
@@ -2,6 +2,7 @@
 #include "ui_about.h"
 
 #include <QDialog>
+#include <common/scm_rev.h>
 
 class AboutDialog : public QDialog
 {
@@ -11,6 +12,9 @@ public:
    {
       mUi.setupUi(this);
       mUi.iconWidget->load(QString(":/images/logo"));
+      mUi.labelBuildInfo->setText(
+         mUi.labelBuildInfo->text().arg(Common::g_build_fullname, Common::g_scm_branch,
+               Common::g_scm_desc, QString(Common::g_build_date).left(10)));
    }
 
 private:

--- a/src/decaf-qt/ui/about.ui
+++ b/src/decaf-qt/ui/about.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>501</width>
-    <height>131</height>
+    <height>150</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,11 +15,36 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QSvgWidget" name="iconWidget" native="true"/>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="1" alignment="Qt::AlignHCenter">
+      <widget class="QLabel" name="labelBuildInfo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4) &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="margin">
+        <number>-4</number>
+       </property>
+      </widget>
      </item>
-     <item>
+     <item row="0" column="1">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>&lt;h1&gt;decaf-emu&lt;/h1&gt;
@@ -31,7 +56,13 @@
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
       </widget>
+     </item>
+     <item row="0" column="0" rowspan="2">
+      <widget class="QSvgWidget" name="iconWidget" native="true"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Was having a little trouble tracking down a regression, so I thought I would add some version information to the about dialog.
Also fixes a minor issue where the license / git hub links didn't do anything.

Looks a little bit like this:
![image](https://user-images.githubusercontent.com/8372950/51721015-9e568200-209b-11e9-9a84-74673555b1f2.png)
