### PR TITLE
fix rpx loading

### DIFF
--- a/src/libdecaf/src/decaf.cpp
+++ b/src/libdecaf/src/decaf.cpp
@@ -116,7 +116,7 @@ initialise(const std::string &gamePath)
       if (std::filesystem::is_regular_file(parent2 / "code" / "cos.xml")) {
          // Found file/../code/cos.xml
          volPath = parent2;
-      } else if (path.extension().compare("rpx") == 0) {
+      } else if (path.extension().compare(".rpx") == 0) {
          // Found file.rpx
          rpxPath = path;
       }


### PR DESCRIPTION
the std::filesystem::extension function includes the dot in the extension it
returns.  Prior to this commit, loading rpx files would fail because the file
extension was being compared to "rpx" instead of ".rpx".