### PR TITLE
fix bitfield byte orders on linux

### DIFF
--- a/src/common/bitfield.h
+++ b/src/common/bitfield.h
@@ -105,7 +105,7 @@ struct BitfieldHelper<BitfieldType, bool, Position, Bits>
 #else
 
 #define BITFIELD_BEG(Name, Type)                                                  \
-   struct Name                                                                \
+   union Name                                                                 \
    {                                                                          \
       using BitfieldType = Name;                                              \
       using StorageType = Type;                                               \


### PR DESCRIPTION
Use a union for bitfields when DECAF_USE_STDLAYOUT_BITFIELD is defined

Previous behavior was to use a struct.  This was causing be2_array
instantiations to use be2_struct for be2_array_item_type instead of be2_val.
The upshot of this was that on Linux builds, byte order would be reversed for
bitfields wrapped in be2_array because be2_struct doesn't do endian reversal.
When DECAF_USE_STDLAYOUT_BITFIELD is not defined, bitfields were already unions,
which is why this behavior did not manifest on Windows.

This commit resolves several programs which were working on Windows but not
Linux and also addresses issue #537 on github.