### PR TITLE
vfs: fix makeFolder failure on GNU/Linux

### DIFF
--- a/src/libdecaf/src/vfs/vfs_host_device.cpp
+++ b/src/libdecaf/src/vfs/vfs_host_device.cpp
@@ -39,7 +39,7 @@ HostDevice::makeFolder(const User &user,
    }
 
    auto error = std::error_code { };
-   if (std::filesystem::create_directory(makeHostPath(path), error)) {
+   if (std::filesystem::create_directories(makeHostPath(path), error)) {
       return Error::Success;
    }
 


### PR DESCRIPTION
SAVEInitSaveDir wants to create a directory hierarchy under usr/save/...
on Linux the create_directory call will fail because it only lets you create one directory at a time, so use create_directories instead.
This was not a problem on Windows because the /std:c++latest compiler option causes create_directory to behave the same as create_directories.

This commit fixes NES and SNES vc games which were working on Windows but not Linux.