### PR TITLE
Vulkan: pass vkGetDeviceProcAddr to vk::DispatchLoaderDynamic::init

### DIFF
--- a/src/libgpu/src/vulkan/vulkan_driver.cpp
+++ b/src/libgpu/src/vulkan/vulkan_driver.cpp
@@ -73,7 +73,7 @@ Driver::initialise(vk::Instance instance,
    validateDevice();
 
    // Initialize the dynamic loader we use for extensions
-   mVkDynLoader.init(instance, ::vkGetInstanceProcAddr, mDevice);
+   mVkDynLoader.init(instance, ::vkGetInstanceProcAddr, mDevice, ::vkGetDeviceProcAddr);
 
    // Initialize our GPU retiler
    mGpuRetiler.initialise(mDevice);


### PR DESCRIPTION
Otherwise, debug builds will fail this assert in the init function:
assert(!!device == !!getDeviceProcAddr);