### PR TITLE
Use abort instead of __builtin_trap on POSIX platforms when assertion fails

### DIFF
--- a/src/common/decaf_assert.h
+++ b/src/common/decaf_assert.h
@@ -28,7 +28,7 @@
 #define decaf_handle_assert(x, e, m) \
    if (UNLIKELY(!(x))) { \
       assertFailed(__FILE__, __LINE__, e, m); \
-      __builtin_trap(); \
+      abort(); \
    }
 
 #define decaf_handle_warn_assert(x, e, m) \
@@ -38,7 +38,7 @@
 
 #define decaf_host_fault(f, t) \
    hostFaultWithStackTrace(f, t); \
-   __builtin_trap();
+   abort();
 
 #endif
 


### PR DESCRIPTION
Heyo!
This simple patch for #562 to bring decaf's assert more in line with the usual behaviour:
> assert() shall write information about the particular call that failed on stderr and shall call abort().

(that's `man 3p assert`)
`__builtin_trap` on gcc can [either call abort or execute an undefined instruction](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html#index-_005f_005fbuiltin_005ftrap), and in my case it was generating an undefined instruction, causing SIGILL, which would find its way to the illegal instruction handler in cpu_host_exception.cpp, which calls decaf_host_fault - one of the assertions that calls __builtin_trap. Quite the loop!
Using abort causes gdb to break (if attached), and also triggers the KDE bugreporting tool; which generates quite a nice backtrace. Haven't tried this on macOS but the behaviour should be similar.
Thanks again!
-Ash