### PR TITLE
common: Add missing <memory> include to log.h

### DIFF
--- a/src/common/log.h
+++ b/src/common/log.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <fmt/core.h>
+#include <memory>
 #include <string_view>
 
 /**


### PR DESCRIPTION
I had to include this header to compile decaf on my machine.