### PR TITLE
libdecaf: Fix lib name in default trace filters

### DIFF
--- a/src/libdecaf/decaf_config.h
+++ b/src/libdecaf/decaf_config.h
@@ -35,14 +35,14 @@ struct LogSettings
    std::vector<std::string> hle_trace_filters =
    {
       "+.*",
-      "-coreinit::__ghsLock",
-      "-coreinit::__ghsUnlock",
-      "-coreinit::__gh_errno_ptr",
-      "-coreinit::__gh_set_errno",
-      "-coreinit::__gh_get_errno",
-      "-coreinit::__get_eh_globals",
-      "-coreinit::OSGetTime",
-      "-coreinit::OSGetSystemTime",
+      "-coreinit.rpl::__ghsLock",
+      "-coreinit.rpl::__ghsUnlock",
+      "-coreinit.rpl::__gh_errno_ptr",
+      "-coreinit.rpl::__gh_set_errno",
+      "-coreinit.rpl::__gh_get_errno",
+      "-coreinit.rpl::__get_eh_globals",
+      "-coreinit.rpl::OSGetTime",
+      "-coreinit.rpl::OSGetSystemTime",
    };
 };
 


### PR DESCRIPTION
My trace filters didn't work until I noticed that I have to add the .rpl extension to the library names. Would have prevented some confusion if the default trace filters were correct.