### PR TITLE
vfs: handle ENOENT on posix systems

### DIFF
--- a/src/libdecaf/src/vfs/vfs_host_device.cpp
+++ b/src/libdecaf/src/vfs/vfs_host_device.cpp
@@ -8,6 +8,9 @@
 #ifdef PLATFORM_WINDOWS
 #include <winerror.h>
 #endif
+#ifdef PLATFORM_POSIX
+#include <errno.h>
+#endif
 
 namespace vfs
 {
@@ -470,6 +473,13 @@ HostDevice::translateError(const std::error_code &ec) const
 
    if (ec.category() == std::system_category()) {
       return translateError(std::system_error { ec });
+   }
+   else if (ec.category() == std::generic_category()) {
+#ifdef PLATFORM_POSIX
+      if (ec.value() == ENOENT) {
+         return Error::NotFound;
+      }
+#endif
    }
 
    return Error::GenericError;


### PR DESCRIPTION
For some reason, std::filesystem::status sets the std::error_code to ENOENT, instead of returning the appropriate std::filesystem::file_status. Decaf only checks the error code on windows systems. On other systems, it always returns Error::GenericError, which is translated to FSAStatus::MediaError. Many games are crashing because of this.