### PR TITLE
ios/mcp: Update title id in mcpPrepareTitle52 if it is DefaultTitleId.

### DIFF
--- a/src/libdecaf/src/ios/mcp/ios_mcp_mcp_device.cpp
+++ b/src/libdecaf/src/ios/mcp/ios_mcp_mcp_device.cpp
@@ -283,6 +283,8 @@ mcpPrepareTitle52(phys_ptr<const MCPRequestPrepareTitle> request,
 
       titleInfoBuffer->titleId = appXml->title_id;
       titleInfoBuffer->groupId = appXml->group_id;
+
+      titleId = appXml->title_id;
    }
 
    // TODO: When we have title switching we will need to read the title id and


### PR DESCRIPTION
I saw the following line in the log: `[08:49:51.880345 info:decaf] No title update found at /vol/storage_mlc01/usr/title/0005000e/fffffffd`

I don't think that's the intended behavior.