### PR TITLE
ci: Upload artifacts for all platforms

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -244,7 +244,6 @@ jobs:
         %QTDIR%/bin/windeployqt.exe --release --no-translations --no-angle --no-opengl-sw decaf-qt.exe
 
     - uses: actions/upload-artifact@master
-      if: startsWith(matrix.os, 'windows')
       with:
-        name: decaf-emu-windows
+        name: decaf-emu-${{ matrix.os }}
         path: build/install


### PR DESCRIPTION
Since all platforms are being built, may as well upload the binaries. Should make it easier to get a hold of latte-assembler.

Only possible breakage is that the Windows build artifact is now called `decaf-emu-windows-cl` rather than `decaf-emu-windows`.