### PR TITLE
libgpu: check return codes, not exceptions, for noexcept vulkan funcs

### DIFF
--- a/src/libgpu/src/vulkan/vulkan_display.cpp
+++ b/src/libgpu/src/vulkan/vulkan_display.cpp
@@ -1242,12 +1242,12 @@ Driver::renderDisplay()
 
    // Acquire the next frame to render into
    auto nextSwapImage = uint32_t { 0 };
-   try {
-      mDevice.acquireNextImageKHR(mDisplayPipeline.swapchain,
-                                  std::numeric_limits<uint64_t>::max(),
-                                  imageAvailableSemaphore, vk::Fence {},
-                                  &nextSwapImage);
-   } catch (vk::OutOfDateKHRError err) {
+   auto result = mDevice.acquireNextImageKHR(mDisplayPipeline.swapchain,
+                                             std::numeric_limits<uint64_t>::max(),
+                                             imageAvailableSemaphore,
+                                             vk::Fence {},
+                                             &nextSwapImage);
+   if (result == vk::Result::eErrorOutOfDateKHR) {
       // Recreate swapchain
       recreateSwapchain(mDisplayPipeline, mPhysDevice, mDevice);
 
@@ -1386,9 +1386,8 @@ Driver::renderDisplay()
       presentInfo.swapchainCount = 1;
       presentInfo.pSwapchains = &mDisplayPipeline.swapchain;
 
-      try {
-         mQueue.presentKHR(presentInfo);
-      } catch (vk::OutOfDateKHRError err) {
+      auto result = mQueue.presentKHR(presentInfo);
+      if (result == vk::Result::eErrorOutOfDateKHR) {
          recreateSwapchain(mDisplayPipeline, mPhysDevice, mDevice);
       }
    }


### PR DESCRIPTION
Around January, vulkan.hpp changed some key functions to be `noexcept`, including `vk::Device::acquireNextImageKHR` and `vk::Queue::presentKHR` ([commit](https://github.com/KhronosGroup/Vulkan-Hpp/commit/e49f02013a5cf32c14e2f912e16e4fa181c8223a)). Decaf checked for swapchain out-of-date conditions with try/catch, which doesn't work on Vulkan SDK versions with this header.

Tested OK on Vulkan SDK 1.2.154.0, linux, mesa 20.2 (selfbuild).