### PR TITLE
Replace deprecated Vulkan validation

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -240,7 +240,7 @@ jobs:
       shell: cmd
       run: |
         cd build/install
-        $QTDIR/bin/windeployqt.exe --release --no-translations --no-angle --no-opengl-sw decaf-qt.exe
+        %QTDIR%/bin/windeployqt.exe --release --no-translations --no-angle --no-opengl-sw decaf-qt.exe
 
     - uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,16 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         name: [
-          macOS-latest-Xcode-11,
+          macOS-latest-Xcode-12,
           ubuntu-20.04-gcc-9,
-#          ubuntu-18.04-clang-7,
           windows-2019-cl,
         ]
         include:
-          - name: macOS-latest-Xcode-11
+          - name: macOS-latest-Xcode-12
             os: macOS-latest
             compiler: xcode
-            version: "11"
+            version: "12"
           - name: ubuntu-20.04-gcc-9
             os: ubuntu-20.04
             compiler: gcc
@@ -241,7 +240,7 @@ jobs:
       shell: cmd
       run: |
         cd build/install
-        %QTDIR%/bin/windeployqt.exe --release --no-translations --no-angle --no-opengl-sw decaf-qt.exe
+        $QTDIR/bin/windeployqt.exe --release --no-translations --no-angle --no-opengl-sw decaf-qt.exe
 
     - uses: actions/upload-artifact@master
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 if(DECAF_VULKAN)
-    find_package(Vulkan 1.1.92.1 REQUIRED) # Vulkan_INCLUDE_DIRS and Vulkan_LIBRARIES
+    find_package(Vulkan 1.1.106.0 REQUIRED) # Vulkan_INCLUDE_DIRS and Vulkan_LIBRARIES
     add_library(vulkan INTERFACE IMPORTED)
     set_target_properties(vulkan PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${Vulkan_INCLUDE_DIRS}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can find us for developer discussion:
 - Linux with a modern C++17 friendly compiler
 - 64 bit
 - CMake v3.2+
-- Vulkan 1.1.92.1+
+- Vulkan 1.1.106.0+
 
 ## Support
 - None, this is an in-development project and user support is not provided.

--- a/src/libgpu/src/vulkan/vulkan_display.cpp
+++ b/src/libgpu/src/vulkan/vulkan_display.cpp
@@ -208,7 +208,7 @@ createVulkanInstance(const gpu::WindowSystemInfo &wsi)
    };
 
    if (gpu::config()->debug.debug_enabled) {
-      layers.push_back("VK_LAYER_LUNARG_standard_validation");
+      layers.push_back("VK_LAYER_KHRONOS_validation");
       extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
    }
 
@@ -343,7 +343,7 @@ createDevice(vk::PhysicalDevice &physicalDevice, vk::SurfaceKHR &surface)
    std::vector<const char *> deviceExtensions = requiredExtensions;
 
    if (gpu::config()->debug.debug_enabled) {
-      deviceLayers.push_back("VK_LAYER_LUNARG_standard_validation");
+      deviceLayers.push_back("VK_LAYER_KHRONOS_validation");
       optionalExtensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
    }
 

--- a/tests/gpu/tiling/vulkan_helpers.cpp
+++ b/tests/gpu/tiling/vulkan_helpers.cpp
@@ -46,7 +46,7 @@ initialiseVulkan()
    std::vector<const char *> instanceExtensions = { };
 
    if (ENABLE_VALIDATION) {
-      instanceLayers.push_back("VK_LAYER_LUNARG_standard_validation");
+      instanceLayers.push_back("VK_LAYER_KHRONOS_validation");
       instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
    }
 
@@ -74,7 +74,7 @@ initialiseVulkan()
    std::vector<const char*> deviceExtensions = { };
 
    if (ENABLE_VALIDATION) {
-      deviceLayers.push_back("VK_LAYER_LUNARG_standard_validation");
+      deviceLayers.push_back("VK_LAYER_KHRONOS_validation");
    }
 
    // Find an appropriate queue


### PR DESCRIPTION
VK_LAYER_LUNARG_standard_validation was deprecated in Vulkan 1.1.106.0 and replaced by  VK_LAYER_KHRONOS_validation. The CI already uses Vulkan 1.2x but when running locally with up to date packages, validation errors occur since the standard_validation is not included in latest Vulkan versions anymore (at least on my machine).

Since VK_LAYER_KHRONOS_validation was introduced after 1.1.92.1, the minimum required version also had to be bumped. I take it this is not an issue though since 1.1.108 is more than one and a half years old by now

Also includes CI fixes for the recent [set-env deprecation](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and [XCode11 deprecation](https://github.com/actions/virtual-environments/issues/1688)