### PR TITLE
Fix QObject::connect: No such slot MainWindow::toggleFullScreen()

### DIFF
--- a/src/decaf-qt/src/mainwindow.cpp
+++ b/src/decaf-qt/src/mainwindow.cpp
@@ -57,7 +57,7 @@ MainWindow::MainWindow(SettingsStorage *settingsStorage,
 
    QShortcut *shortcut = new QShortcut(QKeySequence("F11"), this);
    connect(shortcut, &QShortcut::activated,
-           this, &MainWindow::toggleFullscreen);
+           this, &MainWindow::toggleFullScreen);
    connect(mSoftwareKeyboardDriver, &SoftwareKeyboardDriver::open,
            this, &MainWindow::softwareKeyboardOpen);
    connect(mSoftwareKeyboardDriver, &SoftwareKeyboardDriver::close,
@@ -276,7 +276,7 @@ MainWindow::setTitleListModeGrid()
 }
 
 void
-MainWindow::toggleFullscreen()
+MainWindow::toggleFullScreen()
 {
    if (mUi.menuBar->isVisible()) {
       mUi.menuBar->hide();

--- a/src/decaf-qt/src/mainwindow.h
+++ b/src/decaf-qt/src/mainwindow.h
@@ -40,7 +40,7 @@ private slots:
    void setTitleListModeList();
    void setTitleListModeGrid();
 
-   void toggleFullscreen();
+   void toggleFullScreen();
 
    void openDebugger();
 


### PR DESCRIPTION
Fix
QObject::connect: No such slot MainWindow::toggleFullScreen()
QObject::connect:  (sender name:   'actionViewFullScreen')
QObject::connect:  (receiver name: 'MainWindow')
