### PR TITLE
Audio fixes for 32kHz games

### DIFF
--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
@@ -371,7 +371,8 @@ invokeFinalMixCallback(DeviceTypeData &device,
             auto axChanId = (dev * numChannels) + ch;
 
             for (auto i = 0u; i < numSamples; ++i) {
-               sDeviceData->samples[axChanId][i] = static_cast<int32_t>(samples[dev][ch][i]);
+               int16_t sample = fixed_to_data(samples[dev][ch][i]);
+               sDeviceData->samples[axChanId][i] = static_cast<int32_t>(sample);
             }
 
             sDeviceData->samplePtrs[axChanId] = virt_addrof(sDeviceData->samples[axChanId][0]);

--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
@@ -584,7 +584,7 @@ mixDevice(AXDeviceType type, uint16_t numSamples)
          }
       }
 
-      invokeFinalMixCallback(*devices, numDevices, numChannels, numSamples, mainBus);
+      invokeFinalMixCallback(*devices, numDevices, numChannels, NumOutputSamples, mainBus);
    }
 
    // TODO: Apply compressor


### PR DESCRIPTION
One of the codepaths through the final mix callback would zero 2/3 of the samples before outputting them, which is exciting.
Two patches - one to not zero the samples, and one to let the final mix callback see all the samples, not just 2/3.

Restores audio to Mario Kart 8 and fixes corruption in PUYOPUYOTETRIS. I still get some crunchiness on the audio but that could be my OS not liking when the framerate drops; haven't chased it.

Needs testing on Windows