### PR TITLE
cafe/sndcore2: Fix ADPCM decoding

### DIFF
--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
@@ -185,9 +185,9 @@ struct AudioDecoder
          int sampleData = data[sampleIndex / 2];
 
          if (sampleIndex % 2 == 0) {
-            sampleData &= 0xF;
-         } else {
             sampleData >>= 4;
+         } else {
+            sampleData &= 0xF;
          }
 
          if (sampleData >= 8) {


### PR DESCRIPTION
Looks like this code came from [BrawlLib](https://github.com/libertyernie/brawltools/blob/master/BrawlLib/Wii/Audio/ADPCMState.cs#L68-L71); but has its condition flipped?
Fix makes Mario Kart 8 sound much better.