### PR TITLE
libdecaf: put usercontext in the iosu thread structure

### DIFF
--- a/src/libdecaf/src/ios/ios_stackobject.h
+++ b/src/libdecaf/src/ios/ios_stackobject.h
@@ -20,9 +20,9 @@ public:
    StackObject()
    {
       auto thread = kernel::internal::getCurrentThread();
-      auto ptr = phys_cast<uint8_t *>(thread->stackPointer) - AlignedSize;
+      auto ptr = phys_cast<uint8_t *>(thread->userContext.stackPointer) - AlignedSize;
       phys_ptr<Type>::mAddress = phys_cast<phys_addr>(ptr);
-      thread->stackPointer = ptr;
+      thread->userContext.stackPointer = ptr;
 
       std::uninitialized_default_construct_n(phys_ptr<Type>::get(),
                                              NumElements);
@@ -33,9 +33,9 @@ public:
       std::destroy_n(phys_ptr<Type>::get(), NumElements);
 
       auto thread = kernel::internal::getCurrentThread();
-      auto ptr = phys_cast<uint8_t *>(thread->stackPointer);
+      auto ptr = phys_cast<uint8_t *>(thread->userContext.stackPointer);
       decaf_check(phys_cast<phys_addr>(ptr) == phys_ptr<Type>::mAddress);
-      thread->stackPointer = ptr + AlignedSize;
+      thread->userContext.stackPointer = ptr + AlignedSize;
    }
 };
 

--- a/src/libdecaf/src/ios/kernel/ios_kernel_thread.cpp
+++ b/src/libdecaf/src/ios/kernel/ios_kernel_thread.cpp
@@ -88,7 +88,7 @@ IOS_CreateThread(ThreadEntryFn entry,
    thread->userStackAddr = stackTop;
    thread->userStackSize = stackSize;
    // TODO: thread->sysStackAddr = systemStack + thread->id * 0x400;
-   thread->stackPointer = stackTop - 0x10;
+   thread->userContext.stackPointer = stackTop - 0x10;
 
    internal::memset32(stackTop - stackSize, 0xF5A5A5A5, stackSize);
 

--- a/src/libdecaf/src/ios/kernel/ios_kernel_thread.h
+++ b/src/libdecaf/src/ios/kernel/ios_kernel_thread.h
@@ -22,20 +22,21 @@ using ThreadEntryFn = Error(*)(phys_ptr<void>);
 
 constexpr auto CurrentThread = ThreadId { 0 };
 
-#ifdef IOS_EMULATE_ARM
 struct ContextLLE
 {
    be2_val<uint32_t> cpsr;
-   be2_val<uint32_t> gpr[14];
+   be2_val<uint32_t> gpr[13];
+   be2_val<uint32_t> stackPointer;
    be2_val<uint32_t> lr;
    be2_val<uint32_t> pc;
 };
 CHECK_OFFSET(ContextLLE, 0x00, cpsr);
 CHECK_OFFSET(ContextLLE, 0x04, gpr);
+CHECK_OFFSET(ContextLLE, 0x38, stackPointer);
 CHECK_OFFSET(ContextLLE, 0x3C, lr);
 CHECK_OFFSET(ContextLLE, 0x40, pc);
 CHECK_SIZE(ContextLLE, 0x44);
-#else
+
 struct ContextHLE
 {
    ThreadEntryFn entryPoint;
@@ -46,7 +47,6 @@ struct ContextHLE
    PADDING(0x24);
 };
 CHECK_SIZE(ContextHLE, 0x44);
-#endif
 
 struct ThreadLocalStorage
 {
@@ -76,9 +76,7 @@ struct Thread
    //! The thread queue this therad is currently in.
    be2_phys_ptr<ThreadQueue> threadQueue;
 
-   UNKNOWN(0xA4 - 0x6C);
-   be2_phys_ptr<void> stackPointer;
-   UNKNOWN(0x8);
+   be2_phys_ptr<ContextLLE> userContext;
    be2_phys_ptr<void> sysStackAddr;
    be2_phys_ptr<void> userStackAddr;
    be2_val<uint32_t> userStackSize;
@@ -97,7 +95,7 @@ CHECK_OFFSET(Thread, 0x5C, flags);
 CHECK_OFFSET(Thread, 0x60, exitValue);
 CHECK_OFFSET(Thread, 0x64, joinQueue);
 CHECK_OFFSET(Thread, 0x68, threadQueue);
-CHECK_OFFSET(Thread, 0xA4, stackPointer);
+CHECK_OFFSET(Thread, 0x6C, userContext);
 CHECK_OFFSET(Thread, 0xB0, sysStackAddr);
 CHECK_OFFSET(Thread, 0xB4, userStackAddr);
 CHECK_OFFSET(Thread, 0xB8, userStackSize);


### PR DESCRIPTION
ive been reverse engineering IOS on the wii for a while now and i recently got through its syscalls/thread scheduler.
ive been using the decaf code for a lot of stuff since it shares a lot of code and ideas.

on the wii, the IOS kernel sets the supervisor & undf stackpointer to allocated space within the running's thread structure.
when saving the user thread state, it saves it to the thread structure and then switches to system mode (which shares stackpointer with the thread).

Today i decrypted and verified the same behavior in IOSU, so this fixes that bit.
from what i saw all of this is unused within decaf, but from a documentation standpoint, its more accurate :)

from IOSU's thread schedule : 
![image](https://user-images.githubusercontent.com/12701306/147165679-af86e546-0f5e-4a18-8c94-c8b1e082b7e0.png)

and then in the undefined handler : 
![image](https://user-images.githubusercontent.com/12701306/147254378-50fe2793-acb6-41f9-945c-a859da7a5795.png)


from IOS (ignore the very very ugly code, im yolo'ing all of it without deciding on code guidelines)
https://github.com/DacoTaco/StarStruck/blob/master/kernel/source/interrupt/threads.c#L148-L169
