### PR TITLE
Clarify artifact downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ You can find us for developer discussion:
 - None, this is an in-development project and user support is not provided.
 
 ## Binaries
-The latest Windows binaries are available via [Actions artifacts](https://github.com/decaf-emu/decaf-emu/actions?query=branch%3Amaster+is%3Asuccess).
+The latest Windows and Linux binaries are available via [Actions artifacts](https://github.com/decaf-emu/decaf-emu/actions?query=branch%3Amaster+is%3Asuccess).
 
-Linux binaries are not provided.
+MacOS builds are currently not provided due to complications with Vulkan.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can find us for developer discussion:
 - None, this is an in-development project and user support is not provided.
 
 ## Binaries
-The latest Windows binaries are available via [Actions artifacts](https://github.com/decaf-emu/decaf-emu/actions).
+The latest Windows binaries are available via [Actions artifacts](https://github.com/decaf-emu/decaf-emu/actions?query=branch%3Amaster+is%3Asuccess).
 
 Linux binaries are not provided.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can find us for developer discussion:
 - None, this is an in-development project and user support is not provided.
 
 ## Binaries
-The latest Windows and Linux binaries are available via [Actions artifacts](https://github.com/decaf-emu/decaf-emu/actions?query=branch%3Amaster+is%3Asuccess).
+The latest Windows and Linux binaries are available via [Actions artifacts](https://github.com/decaf-emu/decaf-emu/actions?query=branch%3Amaster+is%3Asuccess). You must be logged into GitHub in order to download the artifacts.
 
 MacOS builds are currently not provided due to complications with Vulkan.
 


### PR DESCRIPTION
Yet Another Readme PR, sorry. This changes the readme instructions to filter out the action runs to only include successful builds on `master`. The section mentions all 3 OSes now, with Linux's state being changed to reflect it now having binaries.

GitHub does not provide a way for users to download the latest artifact from one link. This appears to be achievable via https://nightly.link/, but that would be outside of the scope of this PR.