### PR TITLE
cafe/gx2: Sanitise frontFace in GX2InitPolygonControlReg

### DIFF
--- a/src/libdecaf/src/cafe/libraries/gx2/gx2_registers.cpp
+++ b/src/libdecaf/src/cafe/libraries/gx2/gx2_registers.cpp
@@ -776,7 +776,7 @@ GX2InitPolygonControlReg(virt_ptr<GX2PolygonControlReg> reg,
    auto pa_su_sc_mode_cntl = latte::PA_SU_SC_MODE_CNTL::get(0);
 
    pa_su_sc_mode_cntl = pa_su_sc_mode_cntl
-      .FACE(static_cast<latte::PA_FACE>(frontFace))
+      .FACE(static_cast<latte::PA_FACE>(!!frontFace))
       .CULL_FRONT(!!cullFront)
       .CULL_BACK(!!cullBack)
       .POLY_MODE(!!polyMode)


### PR DESCRIPTION
Hyrule Warriors calls with garbage values, the original gx2 code does an &1 
to solve that.

Allows Hyrule warriors to get a little further, before a rather mystifying stack/heap corruption issue appears instead.