### PR TITLE
cmake: Add hint for ffmpeg headers on Linux

### DIFF
--- a/CMakeModules/FindFFMPEG.cmake
+++ b/CMakeModules/FindFFMPEG.cmake
@@ -1,5 +1,5 @@
 macro(find_component COMPONENT LIBRARY HEADER)
-   find_path(${COMPONENT}_INCLUDE_DIR NAMES "${HEADER}")
+   find_path(${COMPONENT}_INCLUDE_DIR NAMES "${HEADER}" HINTS "/usr/include/ffmpeg")
    find_library(${COMPONENT}_LIBRARY NAMES "${LIBRARY}")
 
    if(${COMPONENT}_INCLUDE_DIR AND ${COMPONENT}_LIBRARY)


### PR DESCRIPTION
Apparently some distros put it here instead - maybe this should use pkg-config eventually? Though I guess you have other plans with vcpkg.

I usually just disabled ffmpeg but it's a hard dependency now.