### PR TITLE
cafe/sndcore2: Add AXVoiceLpf

### DIFF
--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_enum.h
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_enum.h
@@ -124,6 +124,11 @@ ENUM_BEG(AXVoiceSrcRatioResult, int32_t)
    ENUM_VALUE(RatioGreaterThanSomething,  -2)
 ENUM_END(AXVoiceSrcRatioResult)
 
+ENUM_BEG(AXVoiceLpfType, uint16_t)
+   ENUM_VALUE(None, 0)
+   ENUM_VALUE(IIR, 1)
+ENUM_END(AXVoiceLpfType)
+
 ENUM_NAMESPACE_ENTER(internal)
 
 ENUM_BEG(AXVoiceSyncBits, uint32_t)

--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.cpp
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.cpp
@@ -382,6 +382,41 @@ AXSetVoiceLoop(virt_ptr<AXVoice> voice,
    extras->syncBits |= internal::AXVoiceSyncBits::Loop;
 }
 
+void
+AXSetVoiceLpf(virt_ptr<AXVoice> voice,
+              virt_ptr<AXVoiceLpf> lpf)
+{
+   auto extras = internal::getVoiceExtras(voice->index);
+   extras->lpf = *lpf;
+   extras->syncBits |= internal::AXVoiceSyncBits::Lpf;
+}
+
+void
+AXSetVoiceLpfCoefs(virt_ptr<AXVoice> voice,
+                   sfixed_1_0_15_t invCoef,
+                   sfixed_1_0_15_t coef)
+{
+   auto extras = internal::getVoiceExtras(voice->index);
+   auto& lpf = extras->lpf;
+   lpf.invCoef = invCoef;
+   lpf.coef = coef;
+   extras->syncBits |= internal::AXVoiceSyncBits::LpfCoefs;
+}
+
+void
+AXComputeLpfCoefs(int32_t frequency,
+                  virt_ptr<sfixed_1_0_15_t> invCoef,
+                  virt_ptr<sfixed_1_0_15_t> coef)
+{
+   int rate = AXGetInputSamplesPerSec();
+   double omega = 2.0 * M_PI * (double)frequency;
+   double x = 2.0 - cos(omega / (double)rate);
+   double result = sqrt(x*x - 1) - x;
+
+   *invCoef = 1 + result;
+   *coef = -result;
+}
+
 uint32_t
 AXSetVoiceMixerSelect(virt_ptr<AXVoice> voice,
                       uint32_t mixerSelect)
@@ -641,6 +676,7 @@ Library::registerVoiceSymbols()
    RegisterFunctionExport(AXAcquireVoice);
    RegisterFunctionExport(AXAcquireVoiceEx);
    RegisterFunctionExport(AXCheckVoiceOffsets);
+   RegisterFunctionExport(AXComputeLpfCoefs);
    RegisterFunctionExport(AXFreeVoice);
    RegisterFunctionExport(AXGetMaxVoices);
    RegisterFunctionExport(AXGetVoiceCurrentOffsetEx);
@@ -659,6 +695,8 @@ Library::registerVoiceSymbols()
    RegisterFunctionExport(AXSetVoiceLoopOffset);
    RegisterFunctionExport(AXSetVoiceLoopOffsetEx);
    RegisterFunctionExport(AXSetVoiceLoop);
+   RegisterFunctionExport(AXSetVoiceLpf);
+   RegisterFunctionExport(AXSetVoiceLpfCoefs);
    RegisterFunctionExport(AXSetVoiceMixerSelect);
    RegisterFunctionExport(AXSetVoiceOffsets);
    RegisterFunctionExport(AXSetVoiceOffsetsEx);

--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.h
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.h
@@ -161,6 +161,21 @@ CHECK_OFFSET(AXVoiceAdpcm, 0x22, predScale);
 CHECK_OFFSET(AXVoiceAdpcm, 0x24, prevSample);
 CHECK_SIZE(AXVoiceAdpcm, 0x28);
 
+struct AXVoiceLpf
+{
+   be2_val<AXVoiceLpfType> type;
+   be2_val<Pcm16Sample> prevSample;
+   //inverted coef, 1 - coef
+   be2_val<sfixed_1_0_15_t> invCoef;
+   //IIR coef
+   be2_val<sfixed_1_0_15_t> coef;
+};
+CHECK_OFFSET(AXVoiceLpf, 0x0, type);
+CHECK_OFFSET(AXVoiceLpf, 0x2, prevSample);
+CHECK_OFFSET(AXVoiceLpf, 0x4, invCoef);
+CHECK_OFFSET(AXVoiceLpf, 0x6, coef);
+CHECK_SIZE(AXVoiceLpf, 0x8);
+
 // Note: "Src" = "sample rate converter", not "source"
 struct AXVoiceSrc
 {
@@ -190,6 +205,11 @@ AXAcquireVoiceEx(uint32_t priority,
 
 BOOL
 AXCheckVoiceOffsets(virt_ptr<AXVoiceOffsets> offsets);
+
+void
+AXComputeLpfCoefs(int32_t frequency,
+                  virt_ptr<sfixed_1_0_15_t> invCoef,
+                  virt_ptr<sfixed_1_0_15_t> coef);
 
 void
 AXFreeVoice(virt_ptr<AXVoice> voice);
@@ -267,6 +287,15 @@ AXSetVoiceLoopOffsetEx(virt_ptr<AXVoice> voice,
 void
 AXSetVoiceLoop(virt_ptr<AXVoice> voice,
                AXVoiceLoop loop);
+
+void
+AXSetVoiceLpf(virt_ptr<AXVoice> voice,
+              virt_ptr<AXVoiceLpf> lpf);
+
+void
+AXSetVoiceLpfCoefs(virt_ptr<AXVoice> voice,
+                   sfixed_1_0_15_t invCoef,
+                   sfixed_1_0_15_t coef);
 
 uint32_t
 AXSetVoiceMixerSelect(virt_ptr<AXVoice> voice,
@@ -377,7 +406,9 @@ struct AXCafeVoiceExtras
 
    AXVoiceAdpcmLoopData adpcmLoop;
 
-   UNKNOWN(0xe4);
+   AXVoiceLpf lpf;
+
+   UNKNOWN(0xdc);
 
    uint32_t syncBits;
 
@@ -394,6 +425,7 @@ CHECK_OFFSET(AXCafeVoiceExtras, 0x17e, data);
 CHECK_OFFSET(AXCafeVoiceExtras, 0x190, adpcm);
 CHECK_OFFSET(AXCafeVoiceExtras, 0x1b8, src);
 CHECK_OFFSET(AXCafeVoiceExtras, 0x1c6, adpcmLoop);
+CHECK_OFFSET(AXCafeVoiceExtras, 0x1cc, lpf);
 CHECK_OFFSET(AXCafeVoiceExtras, 0x2b0, syncBits);
 CHECK_SIZE(AXCafeVoiceExtras, 0x2c0);
 


### PR DESCRIPTION
An implementation of the AX LPF. The only sound I could actually find which uses it is the back button on the NSMBU title screen, so I didn't have much opportunity to test it thoroughly, but the code agrees with both RE and [the maths](https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter).

Things to note:
- Cafe does all its effects and mixing internally with floats, so I may have messed up somewhere in the conversion to fixed-point maths.
- I put `sfixed_1_0_15_t` in the Cafe-facing HLE API, maybe that's not desirable, I dunno.

At least one other test case would be appreciated if anyone has one.