### PR TITLE
cafe/sndcore2: Implement voice ADSR

### DIFF
--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_device.cpp
@@ -295,6 +295,19 @@ sampleVoice(virt_ptr<AXVoice> voice,
    extras->src.currentOffsetFrac = ufixed_0_16_t { offsetFrac };
 }
 
+void applyADSR(virt_ptr<AXVoice> voice,
+               Pcm16Sample *samples,
+               int numSamples)
+{
+   auto extras = getVoiceExtras(voice->index);
+
+   for (int i = 0; i < numSamples; i++) {
+      samples[i] = samples[i] * (extras->ve.volume.value() + extras->ve.delta.value() * i);
+   }
+
+   extras->ve.volume += extras->ve.delta.value() * numSamples;
+}
+
 void
 decodeVoiceSamples(int numSamples)
 {
@@ -310,6 +323,7 @@ decodeVoiceSamples(int numSamples)
 
       extras->numSamples = numSamples;
       sampleVoice(voice, extras->samples, numSamples);
+      applyADSR(voice, extras->samples, numSamples);
    }
 
    // TODO: Apply Volume Evelope (ADSR)

--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.cpp
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.cpp
@@ -540,10 +540,10 @@ AXSetVoiceVe(virt_ptr<AXVoice> voice,
 
 void
 AXSetVoiceVeDelta(virt_ptr<AXVoice> voice,
-                  int16_t delta)
+                  sfixed_1_0_15_t delta)
 {
    auto extras = internal::getVoiceExtras(voice->index);
-   if (extras->ve.delta != delta) {
+   if (extras->ve.delta.value() != delta) {
       extras->ve.delta = delta;
       voice->syncBits |= internal::AXVoiceSyncBits::VeDelta;
    }

--- a/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.h
+++ b/src/libdecaf/src/cafe/libraries/sndcore2/sndcore2_voice.h
@@ -132,8 +132,8 @@ CHECK_SIZE(AXVoiceDeviceMixData, 0x10);
 
 struct AXVoiceVeData
 {
-   be2_val<uint16_t> volume;
-   be2_val<int16_t> delta;
+   be2_val<ufixed_0_16_t> volume;
+   be2_val<sfixed_1_0_15_t> delta;
 };
 CHECK_OFFSET(AXVoiceVeData, 0x0, volume);
 CHECK_OFFSET(AXVoiceVeData, 0x2, delta);
@@ -320,7 +320,7 @@ AXSetVoiceVe(virt_ptr<AXVoice> voice,
 
 void
 AXSetVoiceVeDelta(virt_ptr<AXVoice> voice,
-                  int16_t delta);
+                  sfixed_1_0_15_t delta);
 
 namespace internal
 {


### PR DESCRIPTION
Adds "ADSR" (actually just per-voice volume scaling) emulation, which significantly improves audio in NSMBU and Mario Kart 8 (the engine sounds specifically). Not much to say, the code is self-explanatory, and unlike my attempts to implement the filters, I know this is correct~