### PR TITLE
cpu: Add program exceptions for bad SPRs in the interpreter

### DIFF
--- a/src/libcpu/cpu_control.h
+++ b/src/libcpu/cpu_control.h
@@ -12,6 +12,7 @@ const uint32_t ALARM_INTERRUPT = 1 << 2;
 const uint32_t DBGBREAK_INTERRUPT = 1 << 3;
 const uint32_t GPU7_INTERRUPT = 1 << 4;
 const uint32_t IPC_INTERRUPT = 1 << 5;
+const uint32_t PROGRAM_INTERRUPT = 1 << 6;
 const uint32_t INTERRUPT_MASK = 0xFFFFFFFF;
 const uint32_t NONMASKABLE_INTERRUPTS = SRESET_INTERRUPT;
 

--- a/src/libcpu/src/interpreter/interpreter_system.cpp
+++ b/src/libcpu/src/interpreter/interpreter_system.cpp
@@ -155,6 +155,8 @@ mfspr(cpu::Core *state, Instruction instr)
       break;
    default:
       gLog->error("Invalid mfspr SPR {}", static_cast<uint32_t>(spr));
+      state->interrupt.fetch_or(cpu::PROGRAM_INTERRUPT);
+      cpu::this_core::checkInterrupts();
    }
 
    state->gpr[instr.rD] = value;
@@ -202,7 +204,9 @@ mtspr(cpu::Core *state, Instruction instr)
       state->gqr[7].value = value;
       break;
    default:
-      decaf_abort(fmt::format("Invalid mtspr SPR {}", static_cast<uint32_t>(spr)));
+      gLog->error("Invalid mtspr SPR {}", static_cast<uint32_t>(spr));
+      state->interrupt.fetch_or(cpu::PROGRAM_INTERRUPT);
+      cpu::this_core::checkInterrupts();
    }
 }
 

--- a/src/libdecaf/src/cafe/kernel/cafe_kernel_exception.cpp
+++ b/src/libdecaf/src/cafe/kernel/cafe_kernel_exception.cpp
@@ -121,6 +121,10 @@ handleCpuInterrupt(cpu::Core *core,
       dispatchException(ExceptionType::Breakpoint, interruptedContext);
    }
 
+   if (flags & cpu::PROGRAM_INTERRUPT) {
+      dispatchException(ExceptionType::Program, interruptedContext);
+   }
+
    // Disable interrupts
    auto originalInterruptMask =
       cpu::this_core::setInterruptMask(cpu::SRESET_INTERRUPT |


### PR DESCRIPTION
Basically this PR stems from me hitting a bad SPR and wondering why it didn't pop open the debugger.

These patches add a new interrupt for program exceptions, add code to the mtspr/mfspr paths in the interpreter to trigger it, and a little code to the Cafe kernel to forward it through to the default exception handler.

The only handled case is a bad SPR number, if this works then later on things like instruction decoding failures can be handled this way too. This is a kinda minimal, notably it *does not set* any of the SRR1 details about exactly what went wrong.

If this is the wrong way to go about this, feel free to let me know. I think something is amiss - the register dump printed on the terminal is wrong - but the debugger does work as expected.